### PR TITLE
fix: RBAC・RLS・トリガ周りのマイグレーションを再整備

### DIFF
--- a/supabase/migrations/20260215000100_schema.sql
+++ b/supabase/migrations/20260215000100_schema.sql
@@ -1,0 +1,261 @@
+-- Supabase向けスキーマ（Auth連携 + RBAC(3ロール) + RLS + 変更制御トリガ）
+-- Roles:
+--   0 = Admin  : 全操作可（タスクの備考(note)編集もAdminのみ）
+--   1 = Leader : タスクのステータス(current_status)変更のみ可（全タスク対象）
+--   2 = User   : 参照のみ（tasksの更新は不可）
+--
+-- 認証は Supabase Auth (auth.users) を利用し、public.users はプロフィール/権限を保持する。
+-- 使い方: Supabase Dashboard → SQL Editor で実行（または migrations に配置）
+
+create extension if not exists pgcrypto;
+
+-- =========================================
+-- 共通: modified 自動更新
+-- =========================================
+create or replace function public.set_modified()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if (tg_op = 'UPDATE') then
+    new.modified := now();
+  end if;
+  return new;
+end;
+$$;
+
+-- =========================================
+-- users: ユーザー（auth.users と連携）
+-- =========================================
+create table if not exists public.users (
+  user_id       uuid primary key references auth.users(id) on delete cascade, -- auth.users.id と一致
+  name          varchar(60)  not null default '（未設定）',  -- 表示名（最大60）
+  email         varchar(254),                              -- メール（NULL可 / 空文字は禁止）
+  role          smallint     not null default 2,           -- 0=Admin,1=Leader,2=User
+  deleted       timestamptz,                               -- 論理削除
+  created       timestamptz  not null default now(),
+  modified      timestamptz  not null default now(),
+  constraint chk_users_role check (role in (0,1,2))
+);
+
+-- =========================================
+-- RBAC helpers (roles: 0=Admin, 1=Leader, 2=User)
+--  - RLSの判定でも使うため、security definer + row_security=off で実装
+-- =========================================
+create or replace function public.user_role()
+returns smallint
+language sql
+stable
+security definer
+set search_path = ''
+set row_security = off
+as $$
+  select u.role
+  from public.users u
+  where u.user_id = auth.uid()
+    and u.deleted is null
+  limit 1
+$$;
+
+create or replace function public.is_admin()
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+set row_security = off
+as $$
+  select coalesce(public.user_role() = 0, false)
+$$;
+
+create or replace function public.is_leader()
+returns boolean
+language sql
+stable
+security definer
+set search_path = ''
+set row_security = off
+as $$
+  select coalesce(public.user_role() = 1, false)
+$$;
+
+-- =========================================
+-- items: 物品マスタ
+-- =========================================
+create table if not exists public.items (
+  item_id    uuid primary key default gen_random_uuid(),
+  name       varchar(80) not null,
+  deleted    timestamptz,
+  created    timestamptz not null default now(),
+  modified   timestamptz not null default now()
+);
+
+-- =========================================
+-- locations: 場所マスタ（階層構造）
+-- =========================================
+create table if not exists public.locations (
+  location_id        uuid primary key default gen_random_uuid(),
+  parent_location_id uuid references public.locations(location_id),
+  name               varchar(80) not null,
+  deleted            timestamptz,
+  created            timestamptz not null default now(),
+  modified           timestamptz not null default now()
+);
+
+-- =========================================
+-- tasks: 物品移動タスク
+-- =========================================
+create table if not exists public.tasks (
+  task_id           uuid primary key default gen_random_uuid(),
+
+  -- 日程
+  date_type         smallint not null, -- 0=日付(YYYY-MM-DD), 1=日時(timestamptz)
+  task_date         date,
+  task_datetime     timestamptz,
+
+  -- 種別
+  schedule_type     smallint not null, -- 0=準備, 1=片付け
+
+  -- 物品/数量
+  item_id           uuid not null references public.items(item_id),
+  quantity          integer not null default 1,
+
+  -- 場所（出発/到着）
+  from_location_id  uuid not null references public.locations(location_id),
+  to_location_id    uuid not null references public.locations(location_id),
+
+  -- 担当
+  created_user_id   uuid not null references public.users(user_id),
+  leader_user_id    uuid references public.users(user_id),
+
+  -- 状態
+  current_status    smallint not null default 0, -- 0=未着手,1=進行中,2=完了
+  note              text,                        -- 備考（Adminのみ編集可）
+
+  deleted           timestamptz,
+  created           timestamptz not null default now(),
+  modified          timestamptz not null default now(),
+
+  constraint chk_tasks_date_type check (date_type in (0,1)),
+  constraint chk_tasks_schedule_type check (schedule_type in (0,1)),
+  constraint chk_tasks_status check (current_status in (0,1,2)),
+  constraint chk_tasks_quantity_positive check (quantity >= 1),
+
+  -- date_type に応じてどちらか必須
+  constraint chk_tasks_date_fields check (
+    (date_type = 0 and task_date is not null and task_datetime is null)
+    or
+    (date_type = 1 and task_datetime is not null and task_date is null)
+  )
+);
+
+-- =========================================
+-- task_activities: タスク履歴
+-- =========================================
+create table if not exists public.task_activities (
+  task_activity_id    uuid primary key default gen_random_uuid(),
+  task_id             uuid not null references public.tasks(task_id),
+  changed_by_user_id  uuid not null references public.users(user_id),
+  action              varchar(40) not null,  -- 例: 'status_change', 'edit', etc
+  payload             jsonb,                 -- 変更内容（任意）
+  created             timestamptz not null default now()
+);
+
+-- =========================================
+-- Trigger: modified 自動更新
+-- =========================================
+drop trigger if exists trg_users_set_modified on public.users;
+create trigger trg_users_set_modified
+before update on public.users
+for each row execute function public.set_modified();
+
+drop trigger if exists trg_items_set_modified on public.items;
+create trigger trg_items_set_modified
+before update on public.items
+for each row execute function public.set_modified();
+
+drop trigger if exists trg_locations_set_modified on public.locations;
+create trigger trg_locations_set_modified
+before update on public.locations
+for each row execute function public.set_modified();
+
+drop trigger if exists trg_tasks_set_modified on public.tasks;
+create trigger trg_tasks_set_modified
+before update on public.tasks
+for each row execute function public.set_modified();
+
+-- =========================================
+-- Check constraints (既存DBでも安全に適用できるよう DO で付与)
+-- =========================================
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'chk_users_email_not_blank'
+  ) then
+    alter table public.users
+      add constraint chk_users_email_not_blank
+      check (email is null or btrim(email) <> '');
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'chk_items_name_not_blank'
+  ) then
+    alter table public.items
+      add constraint chk_items_name_not_blank
+      check (btrim(name) <> '');
+  end if;
+end$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'chk_locations_name_not_blank'
+  ) then
+    alter table public.locations
+      add constraint chk_locations_name_not_blank
+      check (btrim(name) <> '');
+  end if;
+end$$;
+
+-- =========================================
+-- Indexes / Uniques
+-- =========================================
+
+-- users: 有効（deleted IS NULL）かつ email IS NOT NULL のみユニーク
+create unique index if not exists uq_users_email_active
+on public.users (lower(btrim(email)))
+where deleted is null and email is not null;
+
+-- items: 有効レコードのみ name ユニーク
+create unique index if not exists uq_items_name_active
+on public.items (lower(btrim(name)))
+where deleted is null and name is not null;
+
+-- locations:
+-- 1) ルート（parent IS NULL）での name ユニーク（有効のみ）
+create unique index if not exists uq_locations_root_name_active
+on public.locations (lower(btrim(name)))
+where deleted is null and parent_location_id is null and name is not null;
+
+-- 2) 同じ親（同階層）内での name ユニーク（有効のみ）
+create unique index if not exists uq_locations_sibling_name_active
+on public.locations (parent_location_id, lower(btrim(name)))
+where deleted is null and parent_location_id is not null and name is not null;
+
+-- tasks: 検索用
+create index if not exists idx_tasks_item_id on public.tasks(item_id);
+create index if not exists idx_tasks_from_location_id on public.tasks(from_location_id);
+create index if not exists idx_tasks_to_location_id on public.tasks(to_location_id);
+create index if not exists idx_tasks_task_date on public.tasks(task_date);
+create index if not exists idx_tasks_task_datetime on public.tasks(task_datetime);
+
+-- task_activities: 検索用
+create index if not exists idx_task_activities_task_id on public.task_activities(task_id);
+create index if not exists idx_task_activities_changed_by on public.task_activities(changed_by_user_id);

--- a/supabase/migrations/20260215000110_auth_user_trigger.sql
+++ b/supabase/migrations/20260215000110_auth_user_trigger.sql
@@ -1,0 +1,47 @@
+-- Authユーザー作成時に public.users（プロフィール/権限）を自動生成するトリガ
+--  - role は 2(User) 固定（Admin/Leader はDB側で変更）
+--  - name は raw_user_meta_data.name → emailの@前 → '（未設定）' の順に採用
+--  - email が NULL/空の場合は NULL として保存（ユニーク制約は email IS NOT NULL の有効レコードのみ）
+
+create or replace function public.handle_new_auth_user()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_email text;
+  v_name  text;
+begin
+  v_email := nullif(btrim(new.email), '');
+
+  v_name :=
+    nullif(
+      btrim(
+        coalesce(new.raw_user_meta_data->>'name', '')
+      ),
+      ''
+    );
+
+  if v_name is null then
+    if v_email is not null then
+      v_name := split_part(v_email, '@', 1);
+    else
+      v_name := '（未設定）';
+    end if;
+  end if;
+
+  insert into public.users (user_id, name, email, role)
+  values (new.id, left(v_name, 60), v_email, 2)
+  on conflict (user_id) do nothing;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists on_auth_user_created on auth.users;
+
+create trigger on_auth_user_created
+after insert on auth.users
+for each row
+execute function public.handle_new_auth_user();

--- a/supabase/migrations/20260215000130_permissions_triggers.sql
+++ b/supabase/migrations/20260215000130_permissions_triggers.sql
@@ -1,0 +1,134 @@
+-- 権限制御（更新内容制限）トリガ
+-- Roles:
+--   0 = Admin  : 全操作可（タスクの備考(note)編集もAdminのみ）
+--   1 = Leader : タスクのステータス(current_status)変更のみ可（全タスク対象）
+--   2 = User   : 参照のみ（tasksの更新は不可）
+
+-- =========================================
+-- users: 非Adminは name だけ更新可
+-- =========================================
+create or replace function public.enforce_users_update_permissions()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if public.is_admin() then
+    return new;
+  end if;
+
+  -- JWT文脈が無い管理系処理（postgres/service_role等）は許可
+  if auth.uid() is null then
+    return new;
+  end if;
+
+  -- 自分以外の更新は禁止
+  if old.user_id <> auth.uid() then
+    raise exception 'permission denied: cannot update other users';
+  end if;
+
+  -- 非Adminは name 以外の変更不可
+  if (new.user_id, new.email, new.role, new.deleted, new.created, new.modified)
+     is distinct from
+     (old.user_id, old.email, old.role, old.deleted, old.created, old.modified) then
+    raise exception 'permission denied: only name can be changed';
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_users_enforce_update_permissions on public.users;
+
+create trigger trg_users_enforce_update_permissions
+before update on public.users
+for each row execute function public.enforce_users_update_permissions();
+
+-- =========================================
+-- tasks: Leaderは current_status だけ更新可（noteはAdminのみ）
+-- =========================================
+create or replace function public.enforce_tasks_update_permissions()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+declare
+  r smallint;
+begin
+  r := public.user_role();
+
+  if r = 0 then
+    -- Admin: 何でもOK
+    return new;
+  elsif r = 1 then
+    -- Leader: current_status だけ変更可（deleted や note 等は不可）
+    if new.current_status is distinct from old.current_status then
+      -- status以外が変わっていないことを保証
+      if (new.task_id, new.created, new.modified,
+          new.date_type, new.task_date, new.task_datetime,
+          new.schedule_type, new.item_id, new.quantity,
+          new.from_location_id, new.to_location_id,
+          new.created_user_id, new.leader_user_id,
+          new.note, new.deleted) is distinct from
+         (old.task_id, old.created, old.modified,
+          old.date_type, old.task_date, old.task_datetime,
+          old.schedule_type, old.item_id, old.quantity,
+          old.from_location_id, old.to_location_id,
+          old.created_user_id, old.leader_user_id,
+          old.note, old.deleted) then
+        raise exception 'permission denied: leader can only change current_status';
+      end if;
+
+      return new;
+    else
+      raise exception 'permission denied: leader can only change current_status';
+    end if;
+  else
+    -- User: 更新不可
+    raise exception 'permission denied: tasks are read-only for this role';
+  end if;
+end;
+$$;
+
+drop trigger if exists trg_tasks_enforce_update_permissions on public.tasks;
+
+create trigger trg_tasks_enforce_update_permissions
+before update on public.tasks
+for each row execute function public.enforce_tasks_update_permissions();
+
+-- =========================================
+-- tasks: ステータス変更を task_activities に記録
+-- =========================================
+create or replace function public.log_task_status_change()
+returns trigger
+language plpgsql
+set search_path = ''
+as $$
+begin
+  if new.current_status is distinct from old.current_status then
+    insert into public.task_activities (
+      task_id,
+      changed_by_user_id,
+      action,
+      payload
+    )
+    values (
+      new.task_id,
+      auth.uid(),
+      'status_change',
+      jsonb_build_object(
+        'from_status', old.current_status,
+        'to_status', new.current_status
+      )
+    );
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_tasks_log_status_change on public.tasks;
+
+create trigger trg_tasks_log_status_change
+after update of current_status on public.tasks
+for each row execute function public.log_task_status_change();

--- a/supabase/migrations/20260215000140_rls_policies.sql
+++ b/supabase/migrations/20260215000140_rls_policies.sql
@@ -1,0 +1,218 @@
+-- RLS enable + policies
+-- Roles (public.users.role):
+--   0 = Admin  : 全操作可（タスクの備考(note)編集もAdminのみ）
+--   1 = Leader : タスクのステータス(current_status)変更のみ可（全タスク対象）
+--   2 = User   : 参照のみ
+
+-- =========================================
+-- RLS enable
+-- =========================================
+alter table public.users           enable row level security;
+alter table public.items           enable row level security;
+alter table public.locations       enable row level security;
+alter table public.tasks           enable row level security;
+alter table public.task_activities enable row level security;
+
+alter table public.users           force row level security;
+alter table public.items           force row level security;
+alter table public.locations       force row level security;
+alter table public.tasks           force row level security;
+alter table public.task_activities force row level security;
+
+-- =========================================
+-- Drop existing policies (idempotent)
+-- =========================================
+drop policy if exists users_select_own_or_admin              on public.users;
+drop policy if exists users_update_own_or_admin              on public.users;
+
+drop policy if exists items_select_active_or_admin           on public.items;
+drop policy if exists items_insert_admin_only                on public.items;
+drop policy if exists items_update_admin_only                on public.items;
+drop policy if exists items_delete_admin_only                on public.items;
+drop policy if exists items_write_admin_only                 on public.items;
+
+drop policy if exists locations_select_active_or_admin       on public.locations;
+drop policy if exists locations_insert_admin_only            on public.locations;
+drop policy if exists locations_update_admin_only            on public.locations;
+drop policy if exists locations_delete_admin_only            on public.locations;
+drop policy if exists locations_write_admin_only             on public.locations;
+
+drop policy if exists tasks_select_active_or_admin           on public.tasks;
+drop policy if exists tasks_insert_admin_only                on public.tasks;
+drop policy if exists tasks_update_admin_or_leader           on public.tasks;
+drop policy if exists tasks_delete_admin_only                on public.tasks;
+
+drop policy if exists task_activities_select                 on public.task_activities;
+drop policy if exists task_activities_insert_admin_or_leader on public.task_activities;
+
+-- =========================================
+-- users
+-- =========================================
+create policy users_select_own_or_admin
+on public.users
+for select
+to authenticated
+using (
+  (select public.is_admin()) or user_id = (select auth.uid())
+);
+
+create policy users_update_own_or_admin
+on public.users
+for update
+to authenticated
+using (
+  (select public.is_admin()) or user_id = (select auth.uid())
+)
+with check (
+  (select public.is_admin()) or user_id = (select auth.uid())
+);
+
+-- =========================================
+-- items
+-- =========================================
+create policy items_select_active_or_admin
+on public.items
+for select
+to authenticated
+using (
+  (select public.is_admin()) or deleted is null
+);
+
+create policy items_insert_admin_only
+on public.items
+for insert
+to authenticated
+with check (
+  (select public.is_admin())
+);
+
+create policy items_update_admin_only
+on public.items
+for update
+to authenticated
+using (
+  (select public.is_admin())
+)
+with check (
+  (select public.is_admin())
+);
+
+create policy items_delete_admin_only
+on public.items
+for delete
+to authenticated
+using (
+  (select public.is_admin())
+);
+
+-- =========================================
+-- locations
+-- =========================================
+create policy locations_select_active_or_admin
+on public.locations
+for select
+to authenticated
+using (
+  (select public.is_admin()) or deleted is null
+);
+
+create policy locations_insert_admin_only
+on public.locations
+for insert
+to authenticated
+with check (
+  (select public.is_admin())
+);
+
+create policy locations_update_admin_only
+on public.locations
+for update
+to authenticated
+using (
+  (select public.is_admin())
+)
+with check (
+  (select public.is_admin())
+);
+
+create policy locations_delete_admin_only
+on public.locations
+for delete
+to authenticated
+using (
+  (select public.is_admin())
+);
+
+-- =========================================
+-- tasks
+-- =========================================
+create policy tasks_select_active_or_admin
+on public.tasks
+for select
+to authenticated
+using (
+  (select public.is_admin()) or deleted is null
+);
+
+create policy tasks_insert_admin_only
+on public.tasks
+for insert
+to authenticated
+with check (
+  (select public.is_admin())
+);
+
+create policy tasks_update_admin_or_leader
+on public.tasks
+for update
+to authenticated
+using (
+  (select public.is_admin())
+  or ((select public.is_leader()) and deleted is null)
+)
+with check (
+  (select public.is_admin())
+  or ((select public.is_leader()) and deleted is null)
+);
+
+create policy tasks_delete_admin_only
+on public.tasks
+for delete
+to authenticated
+using (
+  (select public.is_admin())
+);
+
+-- =========================================
+-- task_activities
+-- =========================================
+create policy task_activities_select
+on public.task_activities
+for select
+to authenticated
+using (
+  (select public.is_admin())
+  or exists (
+    select 1
+    from public.tasks t
+    where t.task_id = task_activities.task_id
+      and t.deleted is null
+  )
+);
+
+create policy task_activities_insert_admin_or_leader
+on public.task_activities
+for insert
+to authenticated
+with check (
+  (
+    (select public.is_admin())
+    or ((select public.is_leader()) and changed_by_user_id = (select auth.uid()))
+  )
+  and exists (
+    select 1
+    from public.tasks t
+    where t.task_id = task_activities.task_id
+      and t.deleted is null
+  )
+);

--- a/supabase/migrations/20260215000150_grants.sql
+++ b/supabase/migrations/20260215000150_grants.sql
@@ -1,0 +1,28 @@
+-- Grants（RLSが有効なため、権限は最低限+RLSで制御）
+-- Supabaseでは通常、authenticated ロールでアクセス
+
+-- いったんクリア
+revoke all on schema public from authenticated;
+revoke all on all tables in schema public from authenticated;
+revoke all on all sequences in schema public from authenticated;
+revoke all on all functions in schema public from authenticated;
+
+-- スキーマ利用
+grant usage on schema public to authenticated;
+
+-- テーブル権限（RLSが最終防衛線）
+grant select, update on table public.users to authenticated;
+
+grant select, insert, update, delete on table public.items to authenticated;
+grant select, insert, update, delete on table public.locations to authenticated;
+
+grant select, insert, update, delete on table public.tasks to authenticated;
+grant select, insert on table public.task_activities to authenticated;
+
+-- シーケンス（identityがある場合）
+grant usage, select on all sequences in schema public to authenticated;
+
+-- 関数（RLS判定に必要なものだけ）
+grant execute on function public.user_role() to authenticated;
+grant execute on function public.is_admin() to authenticated;
+grant execute on function public.is_leader() to authenticated;

--- a/supabase/verify_manual.sql
+++ b/supabase/verify_manual.sql
@@ -1,0 +1,293 @@
+-- Manual verification SQL for RBAC/RLS/Triggers/Auth sync
+-- Usage:
+--   1) Apply migrations first: `mise run supabase:db:reset`
+--   2) Run this file in psql as a privileged user (e.g. postgres)
+--   3) For Auth trigger verification, also create a user from Supabase Studio/Auth UI
+
+-- ============================================================
+-- 0) Seed minimum verification data (idempotent)
+-- ============================================================
+insert into auth.users (id, aud, role, email, raw_app_meta_data, raw_user_meta_data, created_at, updated_at)
+values
+  ('00000000-0000-0000-0000-0000000000a0', 'authenticated', 'authenticated', 'admin@test.local',  '{}'::jsonb, '{"name":"admin"}'::jsonb, now(), now()),
+  ('00000000-0000-0000-0000-0000000000b0', 'authenticated', 'authenticated', 'leader@test.local', '{}'::jsonb, '{"name":"leader"}'::jsonb, now(), now()),
+  ('00000000-0000-0000-0000-0000000000c0', 'authenticated', 'authenticated', 'user@test.local',   '{}'::jsonb, '{"name":"user"}'::jsonb, now(), now())
+on conflict (id) do nothing;
+
+insert into public.users(user_id, name, email, role)
+values
+  ('00000000-0000-0000-0000-0000000000a0', 'admin',  'admin@test.local',  0),
+  ('00000000-0000-0000-0000-0000000000b0', 'leader', 'leader@test.local', 1),
+  ('00000000-0000-0000-0000-0000000000c0', 'user',   'user@test.local',   2)
+on conflict (user_id) do update
+set
+  name = excluded.name,
+  email = excluded.email,
+  role = excluded.role,
+  deleted = null;
+
+insert into public.items(name)
+values ('verify-item-a')
+on conflict do nothing;
+
+insert into public.locations(name)
+values ('verify-loc-from')
+on conflict do nothing;
+
+insert into public.locations(name)
+values ('verify-loc-to')
+on conflict do nothing;
+
+insert into public.tasks(
+  date_type,
+  task_date,
+  schedule_type,
+  item_id,
+  quantity,
+  from_location_id,
+  to_location_id,
+  created_user_id,
+  leader_user_id,
+  current_status
+)
+select
+  0,
+  current_date,
+  0,
+  (select item_id from public.items where name = 'verify-item-a' and deleted is null limit 1),
+  1,
+  (select location_id from public.locations where name = 'verify-loc-from' and deleted is null limit 1),
+  (select location_id from public.locations where name = 'verify-loc-to' and deleted is null limit 1),
+  '00000000-0000-0000-0000-0000000000a0',
+  '00000000-0000-0000-0000-0000000000b0',
+  0
+where not exists (
+  select 1
+  from public.tasks t
+  where t.created_user_id = '00000000-0000-0000-0000-0000000000a0'
+    and t.leader_user_id = '00000000-0000-0000-0000-0000000000b0'
+    and t.deleted is null
+);
+
+-- ============================================================
+-- 1) Metadata checks: RLS / policies / triggers / functions / grants
+-- ============================================================
+
+-- 1-1) RLS enabled/forced status
+select
+  n.nspname as schema_name,
+  c.relname as table_name,
+  c.relrowsecurity as rls_enabled,
+  c.relforcerowsecurity as rls_forced
+from pg_class c
+join pg_namespace n on n.oid = c.relnamespace
+where n.nspname = 'public'
+  and c.relname in ('users', 'items', 'locations', 'tasks', 'task_activities')
+order by c.relname;
+
+-- 1-2) RLS policy list
+select
+  schemaname,
+  tablename,
+  policyname,
+  cmd,
+  roles,
+  qual,
+  with_check
+from pg_policies
+where schemaname = 'public'
+  and tablename in ('users', 'items', 'locations', 'tasks', 'task_activities')
+order by tablename, policyname;
+
+-- 1-3) Trigger list
+select
+  event_object_schema,
+  event_object_table,
+  trigger_name,
+  action_timing,
+  event_manipulation,
+  action_statement
+from information_schema.triggers
+where event_object_schema in ('public', 'auth')
+order by event_object_schema, event_object_table, trigger_name;
+
+-- 1-4) SECURITY DEFINER functions
+select
+  n.nspname as schema_name,
+  p.proname as function_name,
+  r.rolname as owner_name
+from pg_proc p
+join pg_namespace n on n.oid = p.pronamespace
+join pg_roles r on r.oid = p.proowner
+where n.nspname = 'public'
+  and p.prosecdef
+order by p.proname;
+
+-- 1-5) Table privileges for authenticated
+select
+  table_schema,
+  table_name,
+  privilege_type
+from information_schema.role_table_grants
+where grantee = 'authenticated'
+  and table_schema = 'public'
+  and table_name in ('users', 'items', 'locations', 'tasks', 'task_activities')
+order by table_name, privilege_type;
+
+-- ============================================================
+-- 2) Behavior checks with authenticated role + jwt claims
+-- ============================================================
+-- NOTE:
+--   - execute each block as a privileged user (postgres) in one session
+--   - each block uses BEGIN/ROLLBACK to keep db clean
+
+-- 2-1) USER can SELECT public tables
+begin;
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"00000000-0000-0000-0000-0000000000c0","role":"authenticated"}',
+  true
+);
+
+select 'user_select_items' as check_name, count(*) as rows_count from public.items;
+select 'user_select_locations' as check_name, count(*) as rows_count from public.locations;
+select 'user_select_tasks' as check_name, count(*) as rows_count from public.tasks;
+select 'user_select_task_activities' as check_name, count(*) as rows_count from public.task_activities;
+rollback;
+
+-- 2-2) Non-admin cannot write items/locations (expect ERRORs)
+begin;
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"00000000-0000-0000-0000-0000000000c0","role":"authenticated"}',
+  true
+);
+
+-- expect: permission denied by RLS/policy
+insert into public.items(name) values ('verify-user-write-items');
+update public.items set name = 'verify-user-write-items-2' where name = 'verify-item-a';
+delete from public.items where name = 'verify-user-write-items';
+rollback;
+
+begin;
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"00000000-0000-0000-0000-0000000000c0","role":"authenticated"}',
+  true
+);
+
+-- expect: permission denied by RLS/policy
+insert into public.locations(name) values ('verify-user-write-locations');
+update public.locations set name = 'verify-user-write-locations-2' where name = 'verify-loc-from';
+delete from public.locations where name = 'verify-user-write-locations';
+rollback;
+
+-- 2-3) Non-admin cannot INSERT/DELETE tasks (expect ERRORs)
+begin;
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"00000000-0000-0000-0000-0000000000b0","role":"authenticated"}',
+  true
+);
+
+-- expect: permission denied by RLS/policy
+insert into public.tasks(
+  date_type,
+  task_date,
+  schedule_type,
+  item_id,
+  quantity,
+  from_location_id,
+  to_location_id,
+  created_user_id,
+  leader_user_id,
+  current_status
+)
+select
+  0,
+  current_date,
+  0,
+  (select item_id from public.items where name = 'verify-item-a' and deleted is null limit 1),
+  1,
+  (select location_id from public.locations where name = 'verify-loc-from' and deleted is null limit 1),
+  (select location_id from public.locations where name = 'verify-loc-to' and deleted is null limit 1),
+  '00000000-0000-0000-0000-0000000000b0',
+  '00000000-0000-0000-0000-0000000000b0',
+  0;
+
+delete from public.tasks
+where created_user_id = '00000000-0000-0000-0000-0000000000a0';
+rollback;
+
+-- 2-4) Leader can update current_status only
+begin;
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"00000000-0000-0000-0000-0000000000b0","role":"authenticated"}',
+  true
+);
+
+-- expect: success
+update public.tasks
+set current_status = case when current_status = 0 then 1 else 0 end
+where created_user_id = '00000000-0000-0000-0000-0000000000a0'
+  and leader_user_id = '00000000-0000-0000-0000-0000000000b0';
+rollback;
+
+begin;
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"00000000-0000-0000-0000-0000000000b0","role":"authenticated"}',
+  true
+);
+
+-- expect: ERROR (leader cannot edit note)
+update public.tasks
+set current_status = case when current_status = 0 then 1 else 0 end,
+    note = 'leader-note-should-fail'
+where created_user_id = '00000000-0000-0000-0000-0000000000a0'
+  and leader_user_id = '00000000-0000-0000-0000-0000000000b0';
+rollback;
+
+-- ============================================================
+-- 3) Status-change activity log check
+-- ============================================================
+-- If you have status-change trigger, after_count should increase by updated rows.
+-- If not, after_count stays same (this indicates missing trigger wiring).
+select 'task_activities_before' as check_name, count(*) as cnt from public.task_activities;
+
+begin;
+set local role authenticated;
+select set_config(
+  'request.jwt.claims',
+  '{"sub":"00000000-0000-0000-0000-0000000000b0","role":"authenticated"}',
+  true
+);
+
+update public.tasks
+set current_status = case when current_status = 0 then 1 else 0 end
+where created_user_id = '00000000-0000-0000-0000-0000000000a0'
+  and leader_user_id = '00000000-0000-0000-0000-0000000000b0';
+commit;
+
+select 'task_activities_after' as check_name, count(*) as cnt from public.task_activities;
+
+-- ============================================================
+-- 4) Auth trigger check
+-- ============================================================
+-- Create a new user from Supabase Studio/Auth UI, then run:
+select
+  user_id,
+  name,
+  email,
+  role,
+  created
+from public.users
+order by created desc
+limit 10;


### PR DESCRIPTION
## 概要

PR3 マージ後の main をベースに、RBAC / RLS / トリガ / 権限付与まわりの migration 修正を取り込みました。
（旧PRでの差分を main 向けに載せ替え）

## 変更点

- supabase/migrations に以下を追加
- 20260215000100_schema.sql
- 20260215000110_auth_user_trigger.sql
- 20260215000130_permissions_triggers.sql
- 20260215000140_rls_policies.sql
- 20260215000150_grants.sql
- supabase/verify_manual.sql を追加
- RLSポリシー最適化（auth.uid() を (select auth.uid()) でラップ、FOR ALL の分割）
- SECURITY DEFINER 関数の set search_path = '' 設定を反映

## 関連Issue


## スクリーンショット（UI変更がある場合）

UI変更なし

## 動作確認手順

1. `mise run supabase:start`
2. `mise run supabase:reset`
3. `cat supabase/verify_manual.sql | docker exec -i supabase-db psql -U postgres -d postgres -v ON_ERROR_STOP=0`

## レビューしてほしいポイント

- PR3適用後の main ベースで、migrations差分の再取り込みに過不足がないか
- RLSポリシー/トリガ/権限付与の意図が実装と一致しているか

## セルフチェックリスト

- [ ] ローカルでの動作確認を行った（migration適用の準備まで）
- [ ] Lint エラーが出ていない
- [ ] テストコードを追加・修正した（必要な場合）
