### PR TITLE
fix: tasksの時刻4項目追加とschedule_type拡張

### DIFF
--- a/supabase/migrations/20260215000130_permissions_triggers.sql
+++ b/supabase/migrations/20260215000130_permissions_triggers.sql
@@ -66,12 +66,16 @@ begin
       -- status以外が変わっていないことを保証
       if (new.task_id, new.created, new.modified,
           new.date_type, new.task_date, new.task_datetime,
+          new.planned_start_at, new.planned_end_at,
+          new.actual_start_at, new.actual_end_at,
           new.schedule_type, new.item_id, new.quantity,
           new.from_location_id, new.to_location_id,
           new.created_user_id, new.leader_user_id,
           new.note, new.deleted) is distinct from
          (old.task_id, old.created, old.modified,
           old.date_type, old.task_date, old.task_datetime,
+          old.planned_start_at, old.planned_end_at,
+          old.actual_start_at, old.actual_end_at,
           old.schedule_type, old.item_id, old.quantity,
           old.from_location_id, old.to_location_id,
           old.created_user_id, old.leader_user_id,


### PR DESCRIPTION
## 概要

タスク仕様の追加要件に合わせて、tasksスキーマを拡張します。

## 変更点

- 	asks に以下を追加
  - planned_start_at
  - planned_end_at
  - actual_start_at
  - actual_end_at
- schedule_type 制約を (0,1,2) に拡張
- 時刻の整合性チェック制約を追加
  - 予定開始 <= 予定終了
  - 作業開始 <= 作業終了
  - 作業終了のみ単独入力禁止
- Leader更新制御トリガに新規4列を比較対象として追加

## 動作確認

- migration再適用後、追加列・制約が作成されることを確認
