### PR TITLE
refactor(db): tasksスキーマをevent_day_type中心へ再設計（破壊的変更）

### DIFF
--- a/supabase/migrations/20260215000130_permissions_triggers.sql
+++ b/supabase/migrations/20260215000130_permissions_triggers.sql
@@ -65,15 +65,17 @@ begin
     if new.current_status is distinct from old.current_status then
       -- status以外が変わっていないことを保証
       if (new.task_id, new.created, new.modified,
-          new.date_type, new.task_date, new.task_datetime,
-          new.schedule_type, new.item_id, new.quantity,
+          new.event_day_type, new.item_id, new.quantity,
           new.from_location_id, new.to_location_id,
+          new.scheduled_start_time, new.scheduled_end_time,
+          new.actual_start_time, new.actual_end_time,
           new.created_user_id, new.leader_user_id,
           new.note, new.deleted) is distinct from
          (old.task_id, old.created, old.modified,
-          old.date_type, old.task_date, old.task_datetime,
-          old.schedule_type, old.item_id, old.quantity,
+          old.event_day_type, old.item_id, old.quantity,
           old.from_location_id, old.to_location_id,
+          old.scheduled_start_time, old.scheduled_end_time,
+          old.actual_start_time, old.actual_end_time,
           old.created_user_id, old.leader_user_id,
           old.note, old.deleted) then
         raise exception 'permission denied: leader can only change current_status';

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,0 +1,139 @@
+-- =========================================
+-- Seed data for local development
+-- =========================================
+
+-- auth users
+insert into auth.users (
+	id,
+	aud,
+	role,
+	email,
+	raw_app_meta_data,
+	raw_user_meta_data,
+	created_at,
+	updated_at
+)
+values
+	('10000000-0000-0000-0000-0000000000a0', 'authenticated', 'authenticated', 'admin@goods-go.local', '{}'::jsonb, '{"name":"管理者 太郎"}'::jsonb, now(), now()),
+	('10000000-0000-0000-0000-0000000000b0', 'authenticated', 'authenticated', 'leader@goods-go.local', '{}'::jsonb, '{"name":"指揮者 花子"}'::jsonb, now(), now()),
+	('10000000-0000-0000-0000-0000000000c0', 'authenticated', 'authenticated', 'user@goods-go.local', '{}'::jsonb, '{"name":"一般 次郎"}'::jsonb, now(), now())
+on conflict (id) do nothing;
+
+-- public users (override role)
+insert into public.users (user_id, name, email, role)
+values
+	('10000000-0000-0000-0000-0000000000a0', '管理者 太郎', 'admin@goods-go.local', 0),
+	('10000000-0000-0000-0000-0000000000b0', '指揮者 花子', 'leader@goods-go.local', 1),
+	('10000000-0000-0000-0000-0000000000c0', '一般 次郎', 'user@goods-go.local', 2)
+on conflict (user_id) do update
+set
+	name = excluded.name,
+	email = excluded.email,
+	role = excluded.role,
+	deleted = null;
+
+-- items
+insert into public.items (name)
+values
+	('椅子'),
+	('机'),
+	('テント'),
+	('パネル'),
+	('カラーコーン')
+on conflict do nothing;
+
+-- locations
+insert into public.locations (name)
+values
+	('講義棟102'),
+	('講義棟201'),
+	('AL2'),
+	('体育館前'),
+	('正門広場')
+on conflict do nothing;
+
+-- tasks
+with
+admin_user as (
+	select user_id from public.users where email = 'admin@goods-go.local' and deleted is null limit 1
+),
+leader_user as (
+	select user_id from public.users where email = 'leader@goods-go.local' and deleted is null limit 1
+),
+item_map as (
+	select item_id, name from public.items where deleted is null
+),
+location_map as (
+	select location_id, name from public.locations where deleted is null
+),
+seed_rows as (
+	select *
+	from (
+		values
+			(0, 0, '椅子', '講義棟102', '講義棟201', '08:00'::time, '09:00'::time, null::time, null::time, 10, 'seed-task-01'),
+			(0, 1, '机', 'AL2', '講義棟102', '09:00'::time, '10:00'::time, '09:10'::time, null::time, 8, 'seed-task-02'),
+			(0, 2, 'テント', '体育館前', '正門広場', '10:00'::time, '11:30'::time, '10:00'::time, '11:20'::time, 4, 'seed-task-03'),
+			(1, 0, 'パネル', '講義棟201', 'AL2', '08:30'::time, '09:30'::time, null::time, null::time, 6, 'seed-task-04'),
+			(1, 1, '椅子', '正門広場', '体育館前', '09:30'::time, '10:30'::time, '09:40'::time, null::time, 20, 'seed-task-05'),
+			(1, 2, 'カラーコーン', '講義棟102', '正門広場', '11:00'::time, '12:00'::time, '11:05'::time, '11:50'::time, 12, 'seed-task-06'),
+			(2, 0, '机', '体育館前', '講義棟201', '13:00'::time, '14:00'::time, null::time, null::time, 5, 'seed-task-07'),
+			(2, 1, 'テント', '正門広場', 'AL2', '14:00'::time, '15:30'::time, '14:05'::time, null::time, 3, 'seed-task-08'),
+			(2, 2, '椅子', '講義棟201', '講義棟102', '15:30'::time, '16:30'::time, '15:40'::time, '16:20'::time, 15, 'seed-task-09'),
+			(1, 0, 'パネル', 'AL2', '体育館前', '16:30'::time, '17:30'::time, null::time, null::time, 7, 'seed-task-10'),
+			(0, 1, 'カラーコーン', '講義棟102', 'AL2', '17:30'::time, '18:00'::time, '17:40'::time, null::time, 9, 'seed-task-11'),
+			(2, 2, '机', '講義棟201', '正門広場', '18:00'::time, '19:00'::time, '18:05'::time, '18:50'::time, 4, 'seed-task-12')
+	) as t(
+		event_day_type,
+		current_status,
+		item_name,
+		from_location_name,
+		to_location_name,
+		scheduled_start_time,
+		scheduled_end_time,
+		actual_start_time,
+		actual_end_time,
+		quantity,
+		note
+	)
+)
+insert into public.tasks (
+	event_day_type,
+	item_id,
+	quantity,
+	from_location_id,
+	to_location_id,
+	scheduled_start_time,
+	scheduled_end_time,
+	actual_start_time,
+	actual_end_time,
+	created_user_id,
+	leader_user_id,
+	current_status,
+	note
+)
+select
+	s.event_day_type,
+	i.item_id,
+	s.quantity,
+	fl.location_id,
+	tl.location_id,
+	s.scheduled_start_time,
+	s.scheduled_end_time,
+	s.actual_start_time,
+	s.actual_end_time,
+	a.user_id,
+	l.user_id,
+	s.current_status,
+	s.note
+from seed_rows s
+join item_map i on i.name = s.item_name
+join location_map fl on fl.name = s.from_location_name
+join location_map tl on tl.name = s.to_location_name
+cross join admin_user a
+cross join leader_user l
+where not exists (
+	select 1
+	from public.tasks t
+	where t.note = s.note
+		and t.deleted is null
+);


### PR DESCRIPTION
## 概要
- 管理者タスク一覧実装に合わせて、`tasks` スキーマを後方互換性なしで再設計しました。
- 旧日付系カラム（`date_type`, `task_date`, `task_datetime`, `schedule_type`）を廃止し、`event_day_type` + 時刻4カラム中心のモデルへ統一しています。

## 変更内容
- `supabase/migrations/20260215000100_schema.sql`
  - `tasks` から旧カラムを削除
  - `event_day_type` と時刻4カラムを追加
  - 同一場所禁止・時刻整合性のCHECK制約を追加
  - `deleted is null` 前提の部分インデックスへ更新
- `supabase/migrations/20260215000130_permissions_triggers.sql`
  - `enforce_tasks_update_permissions()` を新スキーマに追随
- `supabase/seed.sql`
  - 開発用seed（users/items/locations/tasks）を追加
- `supabase/verify_manual.sql`
  - 新スキーマに更新し、制約失敗ケース検証を追加

## 影響範囲
- **破壊的変更**: 旧`tasks`カラム前提の実装は動作しません。

## 動作確認
- `npx supabase db reset` 実行成功
- `verify_manual.sql` 実行で以下を確認
  - 非Adminのitems/locations/tasks書き込み拒否（RLS）
  - Leaderの`current_status`のみ更新許可
  - `chk_tasks_locations_different` / `chk_tasks_scheduled_time_order` が発火
  - status変更時の`task_activities`記録増加

## 変更ファイル
- `supabase/migrations/20260215000100_schema.sql`
- `supabase/migrations/20260215000130_permissions_triggers.sql`
- `supabase/seed.sql`
- `supabase/verify_manual.sql`
