### PR TITLE
feat: ユーザー向けタスク画面追加と管理ヘッダー改善

### DIFF
--- a/src/app/(admin)/admin/layout.tsx
+++ b/src/app/(admin)/admin/layout.tsx
@@ -6,7 +6,7 @@ export default async function AdminLayout({ children }: { children: React.ReactN
 
   return (
     <div className="min-h-dvh bg-gray-100">
-      <AdminHeader userName={currentUser.name} />
+      <AdminHeader currentUserName={currentUser.name} currentUserRole={currentUser.role} />
       {children}
     </div>
   );

--- a/src/app/(user)/tasks/page.tsx
+++ b/src/app/(user)/tasks/page.tsx
@@ -1,0 +1,19 @@
+import { parseUserTaskQueryState } from "@/features/user/tasks/model/query-state";
+import { getUserTaskListPageData } from "@/features/user/tasks/server/queries";
+import { TaskListPageView } from "@/features/user/tasks/ui/task-list-page-view";
+
+export const metadata = {
+  title: "タスク一覧",
+  description: "ユーザー向けタスク一覧ページ",
+};
+
+type UserTasksPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function UserTasksPage({ searchParams }: UserTasksPageProps) {
+  const queryState = parseUserTaskQueryState(await searchParams);
+  const { currentUser, tasks, filterOptions } = await getUserTaskListPageData(queryState);
+
+  return <TaskListPageView currentUser={currentUser} tasks={tasks} filterOptions={filterOptions} />;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist_Mono } from "next/font/google";
 import localFont from "next/font/local";
 import { NuqsAdapter } from "nuqs/adapters/next/app";
+import { Toaster } from "@/components/ui/sonner";
 import "./globals.css";
 
 const lineSeedJP = localFont({
@@ -37,9 +38,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="ja">
       <body className={`${lineSeedJP.variable} ${geistMono.variable} antialiased font-sans`}>
         <NuqsAdapter>{children}</NuqsAdapter>
+        <Toaster />
       </body>
     </html>
   );

--- a/src/components/layout/admin-header.tsx
+++ b/src/components/layout/admin-header.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { CircleUserRound, LogOut } from "lucide-react";
+import { ChevronRight, CircleUserRound, LogOut, Shield, X } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
 import { logoutAction } from "@/features/auth/server/actions";
+import { APP_ROLES, getAppRoleLabel, type AppRole } from "@/lib/auth/roles";
 
 type AdminHeaderProps = {
-  userName: string;
+  currentUserName: string;
+  currentUserRole: AppRole;
 };
 
 const navItems = [
@@ -15,8 +21,50 @@ const navItems = [
   { href: "/admin/locations", label: "場所一覧", enabled: false },
 ] as const;
 
-export function AdminHeader({ userName }: AdminHeaderProps) {
+type SwitchRowProps = {
+  href: string;
+  label: string;
+  disabled: boolean;
+  onNavigate: () => void;
+};
+
+function roleIcon(role: AppRole) {
+  if (role === APP_ROLES.ADMIN) {
+    return <Shield className="size-4" aria-hidden="true" />;
+  }
+  return <CircleUserRound className="size-4" aria-hidden="true" />;
+}
+
+function SwitchRow({ href, label, disabled, onNavigate }: SwitchRowProps) {
+  const content = (
+    <>
+      <span>{label}</span>
+      <ChevronRight className="size-4" aria-hidden="true" />
+    </>
+  );
+
+  if (disabled) {
+    return (
+      <div className="flex min-h-11 items-center justify-between rounded-lg px-2 py-1.5 text-sm text-[#595959]">
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      href={href}
+      onClick={onNavigate}
+      className="flex min-h-11 items-center justify-between rounded-lg px-2 py-1.5 text-sm text-[#171717] hover:bg-[#f5f5f5] focus-visible:ring-3 focus-visible:ring-[#121212]/20 focus-visible:ring-offset-2 focus-visible:outline-hidden motion-reduce:transition-none"
+    >
+      {content}
+    </Link>
+  );
+}
+
+export function AdminHeader({ currentUserName, currentUserRole }: AdminHeaderProps) {
   const pathname = usePathname();
+  const [open, setOpen] = useState(false);
 
   return (
     <header className="sticky top-0 z-50 h-15 w-full bg-zinc-900 text-white">
@@ -57,20 +105,89 @@ export function AdminHeader({ userName }: AdminHeaderProps) {
           </nav>
         </div>
 
-        <div className="flex items-center gap-5 text-sm">
-          <div className="flex items-center gap-2">
-            <CircleUserRound className="h-4 w-4" />
-            <span>{userName}</span>
-          </div>
-          <form action={logoutAction}>
-            <button
-              type="submit"
-              className="flex items-center gap-2 text-zinc-200 hover:text-white"
+        <div className="flex items-center text-sm">
+          <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-9 rounded-full p-0 text-zinc-200 hover:bg-white/10 hover:text-white focus-visible:ring-3 focus-visible:ring-white/70 focus-visible:ring-offset-0 focus-visible:outline-hidden motion-reduce:transition-none"
+                aria-label="プロフィールを開く"
+                aria-haspopup="dialog"
+                aria-expanded={open}
+                aria-controls="admin-profile-popover"
+              >
+                <CircleUserRound className="size-8" strokeWidth={1.5} aria-hidden="true" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              id="admin-profile-popover"
+              align="end"
+              sideOffset={12}
+              className="w-[min(92vw,243px)] rounded-[10px] border border-[#e5e5e5] p-5 text-[#0a0a0a] shadow-[0px_10px_15px_-3px_rgba(0,0,0,0.1),0px_4px_6px_-4px_rgba(0,0,0,0.1)] motion-reduce:animate-none"
             >
-              <LogOut className="h-4 w-4" />
-              <span>ログアウト</span>
-            </button>
-          </form>
+              <div className="space-y-3.25">
+                <div className="space-y-2">
+                  <div className="flex justify-end">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => setOpen(false)}
+                      className="size-8 rounded-full text-[#171717] hover:bg-[#f5f5f5] focus-visible:ring-3 focus-visible:ring-[#121212]/20 focus-visible:ring-offset-2 focus-visible:outline-hidden motion-reduce:transition-none"
+                      aria-label="プロフィールを閉じる"
+                    >
+                      <X className="size-4" aria-hidden="true" />
+                    </Button>
+                  </div>
+                  <div className="px-2">
+                    <p className="flex items-baseline gap-1 text-[20px] leading-5 font-medium text-[#0a0a0a]">
+                      <span className="text-xl">{currentUserName}</span>
+                      <span className="text-xs leading-none">さん</span>
+                    </p>
+                  </div>
+                  <div className="rounded-lg px-2 py-1">
+                    <p className="text-xs text-[#0a0a0a]">あなたの現在の役割</p>
+                    <div className="mt-1 flex items-center gap-2 text-base font-medium text-[#0a0a0a]">
+                      {roleIcon(currentUserRole)}
+                      <span>{getAppRoleLabel(currentUserRole)}</span>
+                    </div>
+                  </div>
+                </div>
+
+                <Separator className="bg-[#e5e5e5]" />
+
+                <div className="space-y-2">
+                  <SwitchRow
+                    href="/tasks"
+                    label="ユーザー画面に切り替え"
+                    disabled={false}
+                    onNavigate={() => setOpen(false)}
+                  />
+                  <SwitchRow
+                    href="/admin/tasks"
+                    label="管理者画面に切り替え"
+                    disabled={currentUserRole !== APP_ROLES.ADMIN || pathname.startsWith("/admin")}
+                    onNavigate={() => setOpen(false)}
+                  />
+                </div>
+
+                <Separator className="bg-[#e5e5e5]" />
+
+                <form action={logoutAction}>
+                  <Button
+                    type="submit"
+                    variant="ghost"
+                    className="min-h-11 w-full justify-between rounded-lg px-2 py-1.5 text-sm font-normal text-[#0a0a0a] hover:bg-[#f5f5f5] motion-reduce:transition-none"
+                  >
+                    <span>ログアウト</span>
+                    <LogOut className="size-4" aria-hidden="true" />
+                  </Button>
+                </form>
+              </div>
+            </PopoverContent>
+          </Popover>
         </div>
       </div>
     </header>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -22,6 +22,7 @@ const buttonVariants = cva(
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
         sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
         lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        wide: "h-10 px-14",
         icon: "size-9",
         "icon-sm": "size-8",
         "icon-lg": "size-10",

--- a/src/features/user/tasks/model/mappers.ts
+++ b/src/features/user/tasks/model/mappers.ts
@@ -1,0 +1,54 @@
+import { getAppRoleLabel, type AppRole } from "@/lib/auth/roles";
+import type { TaskStatus } from "./types";
+
+export const EVENT_DAY_OPTIONS = [
+  { value: "0", label: "準々備日" },
+  { value: "1", label: "準備日" },
+  { value: "2", label: "片付け日" },
+] as const;
+
+export const STATUS_OPTIONS = [
+  { value: 0 as TaskStatus, label: "未着手" },
+  { value: 1 as TaskStatus, label: "進行中" },
+  { value: 2 as TaskStatus, label: "完了" },
+] as const;
+
+const statusLabelMap = Object.fromEntries(STATUS_OPTIONS.map((o) => [o.value, o.label])) as Record<
+  TaskStatus,
+  string
+>;
+
+const statusBadgeClassMap: Record<TaskStatus, string> = {
+  0: "bg-[#595959] text-white",
+  1: "bg-[#005BAB] text-white",
+  2: "bg-[#007B48] text-white",
+};
+
+const statusDotClassMap: Record<TaskStatus, string> = {
+  0: "bg-[#595959]",
+  1: "bg-[#005BAB]",
+  2: "bg-[#007B48]",
+};
+
+export function getStatusLabel(value: TaskStatus): string {
+  return statusLabelMap[value];
+}
+
+export function getStatusBadgeClass(value: TaskStatus): string {
+  return statusBadgeClassMap[value];
+}
+
+export function getStatusDotClass(value: TaskStatus): string {
+  return statusDotClassMap[value];
+}
+
+export function normalizeTimeValue(value: string | null): string {
+  if (!value) {
+    return "-";
+  }
+  return value.slice(0, 5);
+}
+
+export function getRoleLabel(role: AppRole): string {
+  return getAppRoleLabel(role);
+}

--- a/src/features/user/tasks/model/query-state.ts
+++ b/src/features/user/tasks/model/query-state.ts
@@ -1,0 +1,39 @@
+import {
+  createSearchParamsCache,
+  parseAsArrayOf,
+  parseAsInteger,
+  parseAsString,
+  parseAsStringLiteral,
+} from "nuqs/server";
+import type { TaskStatus, UserTaskQueryState } from "./types";
+
+export const userTaskQueryStatesParsers = {
+  day: parseAsStringLiteral(["0", "1", "2"] as const).withDefault("0"),
+  statuses: parseAsArrayOf(parseAsInteger).withDefault([]),
+  fromLocationId: parseAsString.withDefault(""),
+  toLocationId: parseAsString.withDefault(""),
+  itemIds: parseAsArrayOf(parseAsString).withDefault([]),
+};
+
+const searchParamsCache = createSearchParamsCache(userTaskQueryStatesParsers);
+
+function isTaskStatus(value: number): value is TaskStatus {
+  return value === 0 || value === 1 || value === 2;
+}
+
+export function parseUserTaskQueryState(
+  searchParams: Record<string, string | string[] | undefined>,
+): UserTaskQueryState {
+  const parsed = searchParamsCache.parse(searchParams);
+  const statuses = parsed.statuses.filter(isTaskStatus);
+
+  return {
+    filters: {
+      day: parsed.day,
+      statuses,
+      fromLocationId: parsed.fromLocationId,
+      toLocationId: parsed.toLocationId,
+      itemIds: parsed.itemIds.filter((itemId) => itemId.length > 0),
+    },
+  };
+}

--- a/src/features/user/tasks/model/types.ts
+++ b/src/features/user/tasks/model/types.ts
@@ -1,0 +1,68 @@
+import type { AppRole } from "@/lib/auth/roles";
+import type { Tables } from "@/types/schema.gen";
+
+export type EventDayType = Tables<"tasks">["event_day_type"] & (0 | 1 | 2);
+export type TaskStatus = Tables<"tasks">["current_status"] & (0 | 1 | 2);
+export const TASK_NOTE_MAX_LENGTH = 1000;
+
+export type UserTaskFilterState = {
+  day: "0" | "1" | "2";
+  statuses: TaskStatus[];
+  fromLocationId: string;
+  toLocationId: string;
+  itemIds: string[];
+};
+
+export type UserTaskQueryState = {
+  filters: UserTaskFilterState;
+};
+
+export type UserTaskFilterOption = {
+  value: string;
+  label: string;
+  group: string;
+};
+
+export type UserTaskFilterOptions = {
+  items: UserTaskFilterOption[];
+  locations: UserTaskFilterOption[];
+};
+
+export type UserTask = {
+  taskId: string;
+  eventDayType: EventDayType;
+  currentStatus: TaskStatus;
+  itemId: string;
+  itemName: string;
+  quantity: number;
+  fromLocationId: string;
+  fromLocationName: string;
+  toLocationId: string;
+  toLocationName: string;
+  scheduledStartTime: string;
+  scheduledEndTime: string;
+  leaderUserId: string | null;
+  leaderName: string | null;
+  note: string | null;
+};
+
+export type UserTaskCurrentUser = {
+  userId: string;
+  name: string;
+  role: AppRole;
+};
+
+export type UserTaskListPageData = {
+  currentUser: UserTaskCurrentUser;
+  tasks: UserTask[];
+  filterOptions: UserTaskFilterOptions;
+};
+
+export type ActionResult =
+  | {
+      ok: true;
+    }
+  | {
+      ok: false;
+      message: string;
+    };

--- a/src/features/user/tasks/server/actions.ts
+++ b/src/features/user/tasks/server/actions.ts
@@ -1,0 +1,67 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { APP_ROLES } from "@/lib/auth/roles";
+import { requireAuthenticatedUser } from "@/lib/auth/guards";
+import { createClient } from "@/lib/supabase/server";
+import { TASK_NOTE_MAX_LENGTH, type ActionResult, type TaskStatus } from "../model/types";
+
+function isTaskStatus(value: number): value is TaskStatus {
+  return value === 0 || value === 1 || value === 2;
+}
+
+export async function updateTaskStatusAction(
+  taskId: string,
+  status: number,
+  note?: string,
+): Promise<ActionResult> {
+  const currentUser = await requireAuthenticatedUser();
+
+  if (currentUser.role !== APP_ROLES.ADMIN && currentUser.role !== APP_ROLES.LEADER) {
+    return { ok: false, message: "ステータスを変更する権限がありません" };
+  }
+
+  if (!taskId) {
+    return { ok: false, message: "対象タスクが見つかりません" };
+  }
+
+  if (!isTaskStatus(status)) {
+    return { ok: false, message: "不正なステータスです" };
+  }
+
+  const isAdmin = currentUser.role === APP_ROLES.ADMIN;
+  if (note !== undefined && !isAdmin) {
+    return { ok: false, message: "備考を変更する権限がありません" };
+  }
+
+  const normalizedNote = note?.trim() ?? "";
+  if (note !== undefined && normalizedNote.length > TASK_NOTE_MAX_LENGTH) {
+    return { ok: false, message: `備考は${TASK_NOTE_MAX_LENGTH}文字以内で入力してください` };
+  }
+
+  const updatePayload: { current_status: TaskStatus; note?: string | null } = {
+    current_status: status,
+  };
+  if (note !== undefined) {
+    updatePayload.note = normalizedNote.length > 0 ? normalizedNote : null;
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("tasks")
+    .update(updatePayload)
+    .select("task_id")
+    .eq("task_id", taskId)
+    .is("deleted", null)
+    .maybeSingle();
+
+  if (error) {
+    return { ok: false, message: "ステータスの更新に失敗しました" };
+  }
+  if (!data) {
+    return { ok: false, message: "対象タスクが見つかりません" };
+  }
+
+  revalidatePath("/tasks");
+  return { ok: true };
+}

--- a/src/features/user/tasks/server/queries.ts
+++ b/src/features/user/tasks/server/queries.ts
@@ -1,0 +1,177 @@
+import { APP_ROLES } from "@/lib/auth/roles";
+import { requireAuthenticatedUser } from "@/lib/auth/guards";
+import { createClient } from "@/lib/supabase/server";
+import type { Tables } from "@/types/schema.gen";
+import { normalizeTimeValue } from "../model/mappers";
+import type {
+  UserTask,
+  UserTaskFilterOption,
+  UserTaskListPageData,
+  UserTaskQueryState,
+} from "../model/types";
+
+type TaskRow = Tables<"tasks">;
+type ItemRow = Tables<"items">;
+type LocationRow = Tables<"locations">;
+type UserRow = Tables<"users">;
+type UserNameRow = Pick<UserRow, "user_id" | "name">;
+
+function toFilterOption(
+  rows: { id: string; name: string; group: string }[],
+): UserTaskFilterOption[] {
+  return rows
+    .map((row) => ({
+      value: row.id,
+      label: row.name,
+      group: row.group,
+    }))
+    .sort((left, right) => left.label.localeCompare(right.label, "ja"));
+}
+
+function mapTask(
+  row: TaskRow,
+  itemNameById: Map<string, string>,
+  locationNameById: Map<string, string>,
+  userNameById: Map<string, string>,
+  currentUserId: string,
+  currentUserName: string,
+): UserTask {
+  const leaderName = !row.leader_user_id
+    ? null
+    : (userNameById.get(row.leader_user_id) ??
+      (row.leader_user_id === currentUserId ? currentUserName : "担当者"));
+
+  return {
+    taskId: row.task_id,
+    eventDayType: row.event_day_type as 0 | 1 | 2,
+    currentStatus: row.current_status as 0 | 1 | 2,
+    itemId: row.item_id,
+    itemName: itemNameById.get(row.item_id) ?? "-",
+    quantity: row.quantity,
+    fromLocationId: row.from_location_id,
+    fromLocationName: locationNameById.get(row.from_location_id) ?? "-",
+    toLocationId: row.to_location_id,
+    toLocationName: locationNameById.get(row.to_location_id) ?? "-",
+    scheduledStartTime: normalizeTimeValue(row.scheduled_start_time),
+    scheduledEndTime: normalizeTimeValue(row.scheduled_end_time),
+    leaderUserId: row.leader_user_id,
+    leaderName,
+    note: row.note,
+  };
+}
+
+export async function getUserTaskListPageData(
+  queryState: UserTaskQueryState,
+): Promise<UserTaskListPageData> {
+  const currentUser = await requireAuthenticatedUser();
+  const supabase = await createClient();
+
+  let tasksQuery = supabase
+    .from("tasks")
+    .select(
+      "task_id,event_day_type,item_id,quantity,from_location_id,to_location_id,scheduled_start_time,scheduled_end_time,leader_user_id,current_status,note,created,deleted",
+    )
+    .eq("event_day_type", Number(queryState.filters.day))
+    .is("deleted", null);
+
+  if (queryState.filters.statuses.length > 0) {
+    tasksQuery = tasksQuery.in("current_status", queryState.filters.statuses);
+  }
+
+  if (queryState.filters.fromLocationId) {
+    tasksQuery = tasksQuery.eq("from_location_id", queryState.filters.fromLocationId);
+  }
+
+  if (queryState.filters.toLocationId) {
+    tasksQuery = tasksQuery.eq("to_location_id", queryState.filters.toLocationId);
+  }
+
+  if (queryState.filters.itemIds.length > 0) {
+    tasksQuery = tasksQuery.in("item_id", queryState.filters.itemIds);
+  }
+
+  const usersPromise = (async () => {
+    if (currentUser.role !== APP_ROLES.ADMIN) {
+      return { data: [] as UserNameRow[], error: null as null };
+    }
+
+    const result = await supabase.from("users").select("user_id,name").is("deleted", null);
+    if (result.error) {
+      return { data: [] as UserNameRow[], error: result.error };
+    }
+
+    return { data: (result.data ?? []) as UserNameRow[], error: null as null };
+  })();
+
+  const [tasksResult, itemsResult, locationsResult, usersResult] = await Promise.all([
+    tasksQuery
+      .order("scheduled_start_time", { ascending: true })
+      .order("created", { ascending: false }),
+    supabase.from("items").select("item_id,name").is("deleted", null),
+    supabase.from("locations").select("location_id,name,parent_location_id").is("deleted", null),
+    usersPromise,
+  ]);
+
+  if (tasksResult.error) {
+    throw new Error(tasksResult.error.message);
+  }
+  if (itemsResult.error) {
+    throw new Error(itemsResult.error.message);
+  }
+  if (locationsResult.error) {
+    throw new Error(locationsResult.error.message);
+  }
+  if (usersResult.error) {
+    throw new Error(usersResult.error.message);
+  }
+
+  const taskRows = (tasksResult.data ?? []) as TaskRow[];
+  const itemRows = (itemsResult.data ?? []) as ItemRow[];
+  const locationRows = (locationsResult.data ?? []) as LocationRow[];
+  const itemNameById = new Map(itemRows.map((item) => [item.item_id, item.name]));
+  const locationNameById = new Map(
+    locationRows.map((location) => [location.location_id, location.name]),
+  );
+  const userNameById = new Map((usersResult.data ?? []).map((user) => [user.user_id, user.name]));
+  userNameById.set(currentUser.userId, currentUser.name);
+  const locationById = new Map(locationRows.map((location) => [location.location_id, location]));
+
+  const locationOptions = toFilterOption(
+    locationRows.map((location) => {
+      const parent =
+        location.parent_location_id && locationById.get(location.parent_location_id)
+          ? locationById.get(location.parent_location_id)?.name
+          : null;
+
+      return {
+        id: location.location_id,
+        name: location.name,
+        group: parent ?? location.name,
+      };
+    }),
+  );
+
+  return {
+    currentUser: {
+      userId: currentUser.userId,
+      name: currentUser.name,
+      role: currentUser.role,
+    },
+    tasks: taskRows.map((row) =>
+      mapTask(
+        row,
+        itemNameById,
+        locationNameById,
+        userNameById,
+        currentUser.userId,
+        currentUser.name,
+      ),
+    ),
+    filterOptions: {
+      items: toFilterOption(
+        itemRows.map((item) => ({ id: item.item_id, name: item.name, group: "物品" })),
+      ),
+      locations: locationOptions,
+    },
+  };
+}

--- a/src/features/user/tasks/ui/task-card.tsx
+++ b/src/features/user/tasks/ui/task-card.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Box, ChevronRight, Clock3 } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+import { getStatusBadgeClass } from "../model/mappers";
+import type { UserTask } from "../model/types";
+
+type TaskCardProps = {
+  task: UserTask;
+  onClick: () => void;
+};
+
+export function TaskCard({ task, onClick }: TaskCardProps) {
+  const statusText =
+    task.currentStatus === 0 ? "未着手" : task.currentStatus === 1 ? "進行中" : "完了";
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full rounded-[10px] bg-white px-4 py-3 text-left shadow-md/20 hover:bg-[#fafafa] sm:px-4"
+      aria-label={`${statusText}。${task.fromLocationName}から${task.toLocationName}へ。予定時刻${task.scheduledStartTime}。${task.itemName}×${task.quantity}`}
+    >
+      <div className="flex items-center justify-between gap-3 sm:gap-6">
+        <div className="flex-1">
+          <Badge
+            className={cn(
+              "h-6 rounded-full px-3 text-xs text-white",
+              getStatusBadgeClass(task.currentStatus),
+            )}
+          >
+            {task.currentStatus === 0 ? "未着手" : task.currentStatus === 1 ? "進行中" : "完了"}
+          </Badge>
+
+          <div className="mt-3 space-y-2">
+            <p className="flex items-center gap-1.5 font-bold">
+              <span className="text-base sm:text-lg">{task.fromLocationName}</span>
+              <span
+                className="inline-block h-0 w-0 border-y-[7px] border-l-10 border-y-transparent border-l-[#919191]"
+                aria-hidden="true"
+              />
+              <span className="sr-only">から</span>
+              <span className="text-base sm:text-lg">{task.toLocationName}</span>
+            </p>
+
+            <div className="flex flex-wrap items-center gap-2 text-sm">
+              <span className="flex items-center gap-1">
+                <Clock3 className="size-3" aria-hidden="true" />
+                {task.scheduledStartTime}
+              </span>
+              <span className="inline-flex items-center gap-0.5 rounded-xl border border-[#e5e5e5] px-3 py-1">
+                <Box className="size-3" aria-hidden="true" />
+                {`${task.itemName}×${task.quantity}`}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <ChevronRight className="size-5 shrink-0 text-[#171717]" aria-hidden="true" />
+      </div>
+    </button>
+  );
+}

--- a/src/features/user/tasks/ui/task-detail-dialog.tsx
+++ b/src/features/user/tasks/ui/task-detail-dialog.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { AlertCircle, Triangle, X } from "lucide-react";
+import { useMemo, useState, useTransition } from "react";
+import { toast } from "sonner";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+import { getStatusDotClass, getStatusLabel } from "../model/mappers";
+import { TASK_NOTE_MAX_LENGTH, type TaskStatus, type UserTask } from "../model/types";
+import { updateTaskStatusAction } from "../server/actions";
+
+type TaskDetailDialogProps = {
+  open: boolean;
+  task: UserTask | null;
+  canEditStatus: boolean;
+  canEditNote: boolean;
+  onOpenChange: (open: boolean) => void;
+};
+
+function statusOptions(): TaskStatus[] {
+  return [0, 1, 2];
+}
+
+export function TaskDetailDialog({
+  open,
+  task,
+  canEditStatus,
+  canEditNote,
+  onOpenChange,
+}: TaskDetailDialogProps) {
+  const [selectedStatus, setSelectedStatus] = useState<TaskStatus>(task?.currentStatus ?? 0);
+  const [noteDraft, setNoteDraft] = useState(task?.note ?? "");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [isPending, startTransition] = useTransition();
+
+  const isDirty = useMemo(() => {
+    if (!task) {
+      return false;
+    }
+    const hasStatusChange = selectedStatus !== task.currentStatus;
+    if (!canEditNote) {
+      return hasStatusChange;
+    }
+    const currentNote = task.note?.trim() ?? "";
+    const draftNote = noteDraft.trim();
+    return hasStatusChange || currentNote !== draftNote;
+  }, [canEditNote, noteDraft, selectedStatus, task]);
+
+  const isNoteTooLong = noteDraft.trim().length > TASK_NOTE_MAX_LENGTH;
+
+  if (!task) {
+    return null;
+  }
+
+  const handleReset = () => {
+    setSelectedStatus(task.currentStatus);
+    setNoteDraft(task.note ?? "");
+    setErrorMessage("");
+  };
+
+  const handleSave = () => {
+    if (!isDirty) {
+      onOpenChange(false);
+      return;
+    }
+
+    const hasStatusChange = selectedStatus !== task.currentStatus;
+    const currentNote = task.note?.trim() ?? "";
+    const nextNote = noteDraft.trim();
+    const hasNoteChange = canEditNote && currentNote !== nextNote;
+
+    setErrorMessage("");
+    startTransition(async () => {
+      const result = await updateTaskStatusAction(
+        task.taskId,
+        selectedStatus,
+        canEditNote ? noteDraft : undefined,
+      );
+      if (!result.ok) {
+        setErrorMessage(result.message);
+        toast.error(result.message);
+        return;
+      }
+      toast.success(
+        hasStatusChange && hasNoteChange
+          ? "ステータスと備考を更新しました"
+          : hasStatusChange
+            ? "ステータスを更新しました"
+            : "備考を更新しました",
+      );
+      onOpenChange(false);
+    });
+  };
+
+  const descriptionId = `task-detail-description-${task.taskId}`;
+  const errorId = errorMessage ? `task-detail-error-${task.taskId}` : undefined;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        showCloseButton={false}
+        className="overflow-y-scroll max-h-screen"
+        aria-describedby={descriptionId}
+        aria-busy={isPending}
+      >
+        <DialogHeader>
+          <div className="flex items-center justify-between">
+            <DialogTitle>タスク詳細</DialogTitle>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => onOpenChange(false)}
+              aria-label="閉じる"
+            >
+              <X className="size-4" />
+            </Button>
+          </div>
+          <DialogDescription id={descriptionId} className="sr-only">
+            タスクの詳細情報を表示し、権限がある場合はステータスや備考を変更できます。
+          </DialogDescription>
+          <Separator />
+        </DialogHeader>
+
+        <div className="space-y-6">
+          <div className="flex flex-col items-center gap-3.5">
+            <p className="font-bold sm:text-lg">{task.fromLocationName}</p>
+            <Triangle className="size-4 rotate-180 fill-[#121212]" aria-hidden="true" />
+            <p className="sm:text-lg font-bold ">{task.toLocationName}</p>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="rounded-xl border border-[#e5e5e5] bg-[#e6e6e6] p-3">
+              <p className="text-sm font-semibold text-[#595959]">
+                {canEditStatus ? "ステータス変更" : "ステータス"}
+              </p>
+              <Select
+                value={String(selectedStatus)}
+                onValueChange={(value) => setSelectedStatus(Number(value) as TaskStatus)}
+                disabled={!canEditStatus}
+              >
+                <SelectTrigger
+                  className="mt-2 h-9 w-full rounded-xl bg-white disabled:cursor-not-allowed disabled:opacity-70"
+                  aria-label="タスクステータス"
+                >
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent className="rounded-xl">
+                  {statusOptions().map((status) => (
+                    <SelectItem key={status} value={String(status)}>
+                      <span className="flex items-center gap-1.5">
+                        <span
+                          className={cn(
+                            "inline-block h-2.5 w-2.5 rounded-full",
+                            getStatusDotClass(status),
+                          )}
+                        />
+                        <span>{getStatusLabel(status)}</span>
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="rounded-xl border border-[#e5e5e5] bg-[#e6e6e6] p-3">
+              <p className="text-sm font-semibold text-[#595959]">物品種類・数量</p>
+              <p className="mt-2 text-sm text-black">
+                <span>{task.itemName}</span>
+                <span className="mx-1">×</span>
+                <span>{task.quantity}</span>
+              </p>
+            </div>
+          </div>
+
+          <section className="space-y-3">
+            <h3 className="text-base font-bold">タスク情報</h3>
+            <div className="rounded-xl bg-[#e6e6e6] p-3">
+              <div className="flex gap-12">
+                <div>
+                  <p className="text-sm font-semibold text-[#595959]">作業予定時刻</p>
+                  <p className="mt-1.5 text-sm">{`${task.scheduledStartTime}〜${task.scheduledEndTime}`}</p>
+                </div>
+              </div>
+
+              <div className="mt-4">
+                <p className="text-sm font-semibold text-[#595959]">担当者</p>
+                <p className="mt-1.5 text-sm">{task.leaderName ?? "未設定"}</p>
+              </div>
+
+              <div className="mt-4">
+                <p className="text-sm font-semibold text-[#595959]">タスク備考</p>
+                <div className="mt-1.5 space-y-2">
+                  <Textarea
+                    value={!canEditNote && !task.note?.trim() ? "なし" : noteDraft}
+                    onChange={(event) => setNoteDraft(event.target.value)}
+                    maxLength={TASK_NOTE_MAX_LENGTH}
+                    disabled={!canEditNote || isPending}
+                    aria-label="タスク備考"
+                    placeholder={canEditNote ? "補足があれば記入してください" : ""}
+                    className="min-h-24 bg-white px-3 py-2.5 text-sm disabled:cursor-not-allowed disabled:opacity-70"
+                  />
+                </div>
+              </div>
+            </div>
+          </section>
+
+          {errorMessage ? (
+            <p
+              id={errorId}
+              role="alert"
+              aria-live="assertive"
+              className="flex items-center gap-1 text-xs text-red-600"
+            >
+              <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />
+              {errorMessage}
+            </p>
+          ) : null}
+
+          {canEditStatus ? (
+            <div className="flex justify-end gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                className="h-10 border-[#121212]"
+                onClick={handleReset}
+                disabled={isPending}
+              >
+                リセット
+              </Button>
+              <Button
+                type="button"
+                className="h-10 bg-[#121212] hover:bg-[#121212]/90"
+                onClick={handleSave}
+                disabled={isPending || (canEditNote && isNoteTooLong)}
+                aria-describedby={errorId}
+              >
+                {isPending ? "保存中..." : "変更保存"}
+              </Button>
+            </div>
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/user/tasks/ui/task-filter-sheet.tsx
+++ b/src/features/user/tasks/ui/task-filter-sheet.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { Triangle } from "lucide-react";
+import { useMemo, type Dispatch, type SetStateAction } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { cn } from "@/lib/utils";
+import { STATUS_OPTIONS } from "../model/mappers";
+import type { UserTaskFilterOptions, UserTaskFilterState } from "../model/types";
+
+type TaskFilterSheetProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  draft: UserTaskFilterState;
+  onDraftChange: Dispatch<SetStateAction<UserTaskFilterState>>;
+  filterOptions: UserTaskFilterOptions;
+  onApply: (filters: UserTaskFilterState) => void;
+};
+
+type FilterChipProps = {
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+};
+
+function FilterChip({ label, selected, onClick }: FilterChipProps) {
+  return (
+    <Button
+      type="button"
+      variant={selected ? "default" : "outline"}
+      size="sm"
+      onClick={onClick}
+      aria-pressed={selected}
+      className={cn(
+        "h-8 rounded-[10px] px-4 text-sm font-normal motion-reduce:transition-none",
+        selected
+          ? "border-[#121212] bg-[#121212] text-[#fafafa] hover:bg-[#121212]/90"
+          : "border-[#171717] bg-white text-[#171717]",
+      )}
+    >
+      {label}
+    </Button>
+  );
+}
+
+export function TaskFilterSheet({
+  open,
+  onOpenChange,
+  draft,
+  onDraftChange,
+  filterOptions,
+  onApply,
+}: TaskFilterSheetProps) {
+  const descriptionId = "task-filter-sheet-description";
+
+  const locationGroups = useMemo(() => {
+    return filterOptions.locations.map((option) => ({ value: option.value, label: option.label }));
+  }, [filterOptions.locations]);
+
+  const toggleStatus = (status: 0 | 1 | 2) => {
+    onDraftChange((prev) => {
+      if (prev.statuses.includes(status)) {
+        return { ...prev, statuses: prev.statuses.filter((value) => value !== status) };
+      }
+      return { ...prev, statuses: [...prev.statuses, status].toSorted() as (0 | 1 | 2)[] };
+    });
+  };
+
+  const toggleItem = (itemId: string) => {
+    onDraftChange((prev) => {
+      if (prev.itemIds.includes(itemId)) {
+        return { ...prev, itemIds: prev.itemIds.filter((value) => value !== itemId) };
+      }
+      return { ...prev, itemIds: [...prev.itemIds, itemId] };
+    });
+  };
+
+  const handleReset = () => {
+    onDraftChange({
+      ...draft,
+      statuses: [],
+      fromLocationId: "",
+      toLocationId: "",
+      itemIds: [],
+    });
+  };
+
+  const handleApply = () => {
+    onApply(draft);
+    onOpenChange(false);
+  };
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerContent id="task-filter-sheet">
+        <div className="mx-auto w-full max-w-sm">
+          <DrawerHeader>
+            <DrawerTitle>タスクの絞り込み</DrawerTitle>
+            <DrawerDescription id={descriptionId} className="sr-only">
+              条件を選択して一覧表示を絞り込みます。
+            </DrawerDescription>
+          </DrawerHeader>
+          <div className="space-y-6 px-4 pb-6 sm:px-6" aria-describedby={descriptionId}>
+            <fieldset className="space-y-2">
+              <legend className="text-base font-bold">ステータス</legend>
+              <div className="flex flex-wrap gap-1.5">
+                {STATUS_OPTIONS.map((status) => (
+                  <FilterChip
+                    key={status.value}
+                    label={status.label}
+                    selected={draft.statuses.includes(status.value)}
+                    onClick={() => toggleStatus(status.value)}
+                  />
+                ))}
+              </div>
+            </fieldset>
+
+            <section className="space-y-2">
+              <h3 id="task-filter-location-label" className="text-base font-bold">
+                場所
+              </h3>
+              <div className="space-y-2">
+                <label htmlFor="task-filter-from-location" className="sr-only">
+                  From（搬入元）
+                </label>
+                <Select
+                  key={`from-${draft.fromLocationId || "placeholder"}`}
+                  value={draft.fromLocationId || undefined}
+                  onValueChange={(value) =>
+                    onDraftChange({
+                      ...draft,
+                      fromLocationId: value === "__none__" ? "" : value,
+                    })
+                  }
+                >
+                  <SelectTrigger
+                    id="task-filter-from-location"
+                    className="h-9 w-full rounded-lg border-[#121212] px-3 text-sm"
+                    aria-label="From（搬入元）"
+                  >
+                    <SelectValue placeholder="From（搬入元）" />
+                  </SelectTrigger>
+                  <SelectContent className="rounded-lg p-1 shadow-[0px_4px_6px_rgba(0,0,0,0.1),0px_2px_4px_rgba(0,0,0,0.1)]">
+                    <SelectItem value="__none__">未選択</SelectItem>
+                    {locationGroups.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+
+                <div className="flex justify-center">
+                  <Triangle
+                    className="size-6 rotate-180 fill-[#121212] text-[#121212]"
+                    aria-hidden="true"
+                  />
+                </div>
+
+                <label htmlFor="task-filter-to-location" className="sr-only">
+                  To（搬入先）
+                </label>
+                <Select
+                  key={`to-${draft.toLocationId || "placeholder"}`}
+                  value={draft.toLocationId || undefined}
+                  onValueChange={(value) =>
+                    onDraftChange({
+                      ...draft,
+                      toLocationId: value === "__none__" ? "" : value,
+                    })
+                  }
+                >
+                  <SelectTrigger
+                    id="task-filter-to-location"
+                    className="h-9 w-full rounded-lg border-[#121212] px-3 text-sm"
+                    aria-label="To（搬入先）"
+                  >
+                    <SelectValue placeholder="To（搬入先）" />
+                  </SelectTrigger>
+                  <SelectContent className="rounded-lg p-1 shadow-[0px_4px_6px_rgba(0,0,0,0.1),0px_2px_4px_rgba(0,0,0,0.1)]">
+                    <SelectItem value="__none__">未選択</SelectItem>
+                    {locationGroups.map((option) => (
+                      <SelectItem key={option.value} value={option.value}>
+                        {option.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </section>
+
+            <fieldset className="space-y-2">
+              <legend className="text-base font-bold">物品</legend>
+              <div className="flex flex-wrap gap-1.5">
+                {filterOptions.items.map((item) => (
+                  <FilterChip
+                    key={item.value}
+                    label={item.label}
+                    selected={draft.itemIds.includes(item.value)}
+                    onClick={() => toggleItem(item.value)}
+                  />
+                ))}
+              </div>
+            </fieldset>
+
+            <Separator className="bg-[#e5e5e5]" />
+
+            <div className="flex items-center justify-end gap-3">
+              <Button
+                type="button"
+                variant="outline"
+                className="h-10 rounded-lg border-[#121212]"
+                onClick={handleReset}
+              >
+                リセット
+              </Button>
+              <Button
+                type="button"
+                size="wide"
+                className="h-10 rounded-lg bg-[#121212] hover:bg-[#121212]/90"
+                onClick={handleApply}
+              >
+                絞りこむ
+              </Button>
+            </div>
+          </div>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}

--- a/src/features/user/tasks/ui/task-list-page-view.tsx
+++ b/src/features/user/tasks/ui/task-list-page-view.tsx
@@ -1,0 +1,168 @@
+"use client";
+
+import { Funnel } from "lucide-react";
+import { useQueryStates } from "nuqs";
+import { useMemo, useState, useTransition } from "react";
+import { Button } from "@/components/ui/button";
+import { APP_ROLES, type AppRole } from "@/lib/auth/roles";
+import { userTaskQueryStatesParsers } from "../model/query-state";
+import type {
+  TaskStatus,
+  UserTask,
+  UserTaskFilterOptions,
+  UserTaskFilterState,
+} from "../model/types";
+import { TaskCard } from "./task-card";
+import { TaskDetailDialog } from "./task-detail-dialog";
+import { TaskFilterSheet } from "./task-filter-sheet";
+import { UserTaskHeader } from "./user-task-header";
+
+type TaskListPageViewProps = {
+  currentUser: {
+    userId: string;
+    name: string;
+    role: AppRole;
+  };
+  tasks: UserTask[];
+  filterOptions: UserTaskFilterOptions;
+};
+
+function isTaskStatus(value: number): value is TaskStatus {
+  return value === 0 || value === 1 || value === 2;
+}
+
+export function TaskListPageView({ currentUser, tasks, filterOptions }: TaskListPageViewProps) {
+  const [qs, setQs] = useQueryStates(userTaskQueryStatesParsers, { shallow: false });
+  const [isPending, startTransition] = useTransition();
+
+  const [isFilterOpen, setIsFilterOpen] = useState(false);
+  const [filterDraft, setFilterDraft] = useState<UserTaskFilterState>({
+    day: "0",
+    statuses: [],
+    fromLocationId: "",
+    toLocationId: "",
+    itemIds: [],
+  });
+  const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
+
+  const filters: UserTaskFilterState = useMemo(
+    () => ({
+      day: qs.day,
+      statuses: qs.statuses.filter(isTaskStatus),
+      fromLocationId: qs.fromLocationId,
+      toLocationId: qs.toLocationId,
+      itemIds: qs.itemIds.filter((itemId) => itemId.length > 0),
+    }),
+    [qs.day, qs.fromLocationId, qs.itemIds, qs.statuses, qs.toLocationId],
+  );
+  const selectedTask = useMemo(
+    () => tasks.find((task) => task.taskId === selectedTaskId) ?? null,
+    [selectedTaskId, tasks],
+  );
+
+  const canEditStatus =
+    currentUser.role === APP_ROLES.ADMIN || currentUser.role === APP_ROLES.LEADER;
+  const canEditNote = currentUser.role === APP_ROLES.ADMIN;
+
+  const handleDayChange = (day: "0" | "1" | "2") => {
+    startTransition(() => {
+      setQs({ day });
+    });
+  };
+
+  const handleApplyFilter = (nextFilters: UserTaskFilterState) => {
+    startTransition(() => {
+      setQs({
+        statuses: nextFilters.statuses,
+        fromLocationId: nextFilters.fromLocationId,
+        toLocationId: nextFilters.toLocationId,
+        itemIds: nextFilters.itemIds,
+      });
+    });
+  };
+
+  return (
+    <main className="min-h-dvh bg-[#f3f4f6]">
+      <h1 className="sr-only">タスク一覧</h1>
+
+      <UserTaskHeader
+        currentDay={filters.day}
+        currentRole={currentUser.role}
+        currentUserName={currentUser.name}
+        onDayChange={handleDayChange}
+      />
+
+      <section
+        className="mx-auto w-full max-w-3xl space-y-4 px-3 pb-10 pt-4 sm:px-4"
+        aria-labelledby="task-list-heading"
+        aria-busy={isPending}
+      >
+        <h2 id="task-list-heading" className="sr-only">
+          表示中のタスク一覧
+        </h2>
+
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            size="lg"
+            className="rounded-xl text-xs hover:bg-[#121212]/90"
+            aria-haspopup="dialog"
+            aria-expanded={isFilterOpen}
+            aria-controls="task-filter-sheet"
+            onClick={() => {
+              setFilterDraft(filters);
+              setIsFilterOpen(true);
+            }}
+          >
+            <Funnel className="size-3.5" aria-hidden="true" />
+            絞り込む
+          </Button>
+        </div>
+
+        {tasks.length > 0 ? (
+          <ul role="list" className="space-y-2">
+            {tasks.map((task) => (
+              <li key={task.taskId}>
+                <TaskCard task={task} onClick={() => setSelectedTaskId(task.taskId)} />
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        {!isPending && tasks.length === 0 ? (
+          <div
+            className="rounded-lg border border-[#e5e5e5] bg-white px-4 py-8 shadow-sm"
+            role="status"
+            aria-live="polite"
+          >
+            <p className="text-center text-sm text-[#737373]">該当するタスクはありません</p>
+          </div>
+        ) : null}
+      </section>
+
+      {isFilterOpen ? (
+        <TaskFilterSheet
+          open={isFilterOpen}
+          onOpenChange={setIsFilterOpen}
+          draft={filterDraft}
+          onDraftChange={setFilterDraft}
+          filterOptions={filterOptions}
+          onApply={handleApplyFilter}
+        />
+      ) : null}
+
+      <TaskDetailDialog
+        key={`${selectedTask?.taskId ?? "none"}:${selectedTask?.currentStatus ?? "-1"}:${selectedTask?.note ?? ""}`}
+        open={selectedTask !== null}
+        task={selectedTask}
+        canEditStatus={canEditStatus}
+        canEditNote={canEditNote}
+        onOpenChange={(open) => {
+          if (!open) {
+            setSelectedTaskId(null);
+          }
+        }}
+      />
+    </main>
+  );
+}

--- a/src/features/user/tasks/ui/task-list-page-view.tsx
+++ b/src/features/user/tasks/ui/task-list-page-view.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { Funnel } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useQueryStates } from "nuqs";
 import { useMemo, useState, useTransition } from "react";
 import { Button } from "@/components/ui/button";
+import { Spinner } from "@/components/ui/spinner";
 import { APP_ROLES, type AppRole } from "@/lib/auth/roles";
 import { userTaskQueryStatesParsers } from "../model/query-state";
 import type {
@@ -32,6 +34,7 @@ function isTaskStatus(value: number): value is TaskStatus {
 }
 
 export function TaskListPageView({ currentUser, tasks, filterOptions }: TaskListPageViewProps) {
+  const router = useRouter();
   const [qs, setQs] = useQueryStates(userTaskQueryStatesParsers, { shallow: false });
   const [isPending, startTransition] = useTransition();
 
@@ -81,6 +84,12 @@ export function TaskListPageView({ currentUser, tasks, filterOptions }: TaskList
     });
   };
 
+  const handleRefresh = () => {
+    startTransition(() => {
+      router.refresh();
+    });
+  };
+
   return (
     <main className="min-h-dvh bg-[#f3f4f6]">
       <h1 className="sr-only">タスク一覧</h1>
@@ -101,7 +110,18 @@ export function TaskListPageView({ currentUser, tasks, filterOptions }: TaskList
           表示中のタスク一覧
         </h2>
 
-        <div className="flex justify-end">
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="lg"
+            className="rounded-xl border-[#121212] text-xs"
+            onClick={handleRefresh}
+            disabled={isPending}
+          >
+            {isPending ? <Spinner className="size-3.5" aria-label="更新中" /> : null}
+            {isPending ? "更新中..." : "更新"}
+          </Button>
           <Button
             type="button"
             size="lg"

--- a/src/features/user/tasks/ui/user-task-header.tsx
+++ b/src/features/user/tasks/ui/user-task-header.tsx
@@ -77,7 +77,7 @@ export function UserTaskHeader({
   const disableAdminSwitch = currentRole !== APP_ROLES.ADMIN;
 
   return (
-    <header className="bg-[#121212] text-[#fafafa]">
+    <header className="sticky top-0 bg-[#121212] text-[#fafafa]">
       <div className="mx-auto w-full max-w-3xl space-y-4 px-6 pb-1 pt-4 sm:px-4">
         <div className="flex justify-end">
           <Popover open={open} onOpenChange={setOpen}>

--- a/src/features/user/tasks/ui/user-task-header.tsx
+++ b/src/features/user/tasks/ui/user-task-header.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { ChevronRight, CircleUserRound, LogOut, Shield, UserRound, X } from "lucide-react";
+import Link from "next/link";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { Separator } from "@/components/ui/separator";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { APP_ROLES, type AppRole } from "@/lib/auth/roles";
+import { logoutAction } from "@/features/auth/server/actions";
+import { EVENT_DAY_OPTIONS, getRoleLabel } from "../model/mappers";
+
+type UserTaskHeaderProps = {
+  currentDay: "0" | "1" | "2";
+  currentRole: AppRole;
+  currentUserName: string;
+  onDayChange: (day: "0" | "1" | "2") => void;
+};
+
+function isEventDay(value: string): value is "0" | "1" | "2" {
+  return value === "0" || value === "1" || value === "2";
+}
+
+function roleIcon(role: AppRole) {
+  if (role === APP_ROLES.ADMIN) {
+    return <Shield className="size-4" />;
+  }
+  return <UserRound className="size-4" />;
+}
+
+type SwitchRowProps = {
+  href: string;
+  label: string;
+  disabled: boolean;
+  onNavigate: () => void;
+};
+
+function SwitchRow({ href, label, disabled, onNavigate }: SwitchRowProps) {
+  const content = (
+    <>
+      <span>{label}</span>
+      <ChevronRight className="size-4" aria-hidden="true" />
+    </>
+  );
+
+  if (disabled) {
+    return (
+      <div
+        className="flex min-h-11 items-center justify-between rounded-lg px-2 py-1.5 text-sm text-[#595959]"
+        aria-disabled="true"
+      >
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      href={href}
+      onClick={onNavigate}
+      className="flex min-h-11 items-center justify-between rounded-lg px-2 py-1.5 text-sm hover:bg-[#f5f5f5]"
+    >
+      {content}
+    </Link>
+  );
+}
+
+export function UserTaskHeader({
+  currentDay,
+  currentRole,
+  currentUserName,
+  onDayChange,
+}: UserTaskHeaderProps) {
+  const [open, setOpen] = useState(false);
+  const disableUserSwitch = currentRole === APP_ROLES.USER;
+  const disableAdminSwitch = currentRole !== APP_ROLES.ADMIN;
+
+  return (
+    <header className="bg-[#121212] text-[#fafafa]">
+      <div className="mx-auto w-full max-w-3xl space-y-4 px-6 pb-1 pt-4 sm:px-4">
+        <div className="flex justify-end">
+          <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-9 rounded-full p-0 text-[#e1e1e1] hover:bg-white/10 hover:text-white"
+                aria-label="プロフィールを開く"
+                aria-haspopup="dialog"
+                aria-expanded={open}
+                aria-controls="user-task-profile-popover"
+              >
+                <CircleUserRound className="size-8" strokeWidth={1.5} />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent
+              id="user-task-profile-popover"
+              align="end"
+              sideOffset={12}
+              className="w-[min(92vw,243px)] rounded-[10px] p-5"
+            >
+              <div className="space-y-3.25">
+                <div className="space-y-2">
+                  <div className="flex justify-end">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => setOpen(false)}
+                      className="size-8 rounded-full hover:bg-[#f5f5f5]"
+                      aria-label="プロフィールを閉じる"
+                    >
+                      <X className="size-4" />
+                    </Button>
+                  </div>
+                  <div className="px-2">
+                    <p className="flex items-baseline gap-1 text-xl leading-5 font-medium">
+                      <span>{currentUserName}</span>
+                      <span className="text-xs leading-none">さん</span>
+                    </p>
+                  </div>
+                  <div className="rounded-lg px-2 py-1">
+                    <p className="text-xs">あなたの現在の役割</p>
+                    <div className="mt-1 flex items-center gap-2 text-base font-medium">
+                      {roleIcon(currentRole)}
+                      <span>{getRoleLabel(currentRole)}</span>
+                    </div>
+                  </div>
+                </div>
+
+                <Separator />
+
+                <div className="space-y-2">
+                  <SwitchRow
+                    href="/tasks"
+                    label="ユーザー画面に切り替え"
+                    disabled={disableUserSwitch}
+                    onNavigate={() => setOpen(false)}
+                  />
+                  <SwitchRow
+                    href="/admin/tasks"
+                    label="管理者画面に切り替え"
+                    disabled={disableAdminSwitch}
+                    onNavigate={() => setOpen(false)}
+                  />
+                </div>
+
+                <Separator />
+
+                <form action={logoutAction}>
+                  <Button
+                    type="submit"
+                    variant="ghost"
+                    className="min-h-11 w-full justify-between hover:bg-[#f5f5f5]"
+                  >
+                    <span>ログアウト</span>
+                    <LogOut className="size-4" aria-hidden="true" />
+                  </Button>
+                </form>
+              </div>
+            </PopoverContent>
+          </Popover>
+        </div>
+
+        <Tabs
+          value={currentDay}
+          onValueChange={(value) => {
+            if (isEventDay(value)) {
+              onDayChange(value);
+            }
+          }}
+          className="w-full gap-0"
+        >
+          <TabsList className="h-auto w-full gap-2 rounded-none bg-transparent p-0 sm:gap-4">
+            {EVENT_DAY_OPTIONS.map((option) => (
+              <TabsTrigger
+                key={option.value}
+                value={option.value}
+                className="h-10 flex-1 rounded-none border-x-0 border-t-0 border-b-4 border-transparent px-1 pb-3 font-bold text-[#e1e1e1] data-[state=active]:border-[#fafafa] data-[state=active]:bg-transparent data-[state=active]:text-[#fafafa] data-[state=active]:shadow-none"
+              >
+                {option.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      </div>
+    </header>
+  );
+}

--- a/src/lib/auth/roles.ts
+++ b/src/lib/auth/roles.ts
@@ -13,3 +13,13 @@ export type AppRole = Tables<"users">["role"] & (typeof APP_ROLE_VALUES)[number]
 export function isAppRole(value: unknown): value is AppRole {
   return typeof value === "number" && APP_ROLE_VALUES.some((roleValue) => roleValue === value);
 }
+
+export function getAppRoleLabel(role: AppRole): string {
+  if (role === APP_ROLES.ADMIN) {
+    return "管理者";
+  }
+  if (role === APP_ROLES.LEADER) {
+    return "指揮者";
+  }
+  return "ユーザー";
+}

--- a/src/types/css.d.ts
+++ b/src/types/css.d.ts
@@ -1,19 +1,19 @@
-declare module '*.module.css' {
+declare module "*.module.css" {
   const classes: { readonly [key: string]: string };
   export default classes;
 }
 
-declare module '*.module.scss' {
+declare module "*.module.scss" {
   const classes: { readonly [key: string]: string };
   export default classes;
 }
 
-declare module '*.module.sass' {
+declare module "*.module.sass" {
   const classes: { readonly [key: string]: string };
   export default classes;
 }
 
-declare module '*.css';
-declare module '*.scss';
-declare module '*.sass';
-declare module '*.less';
+declare module "*.css";
+declare module "*.scss";
+declare module "*.sass";
+declare module "*.less";

--- a/src/types/css.d.ts
+++ b/src/types/css.d.ts
@@ -1,0 +1,19 @@
+declare module '*.module.css' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.module.scss' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.module.sass' {
+  const classes: { readonly [key: string]: string };
+  export default classes;
+}
+
+declare module '*.css';
+declare module '*.scss';
+declare module '*.sass';
+declare module '*.less';


### PR DESCRIPTION
## 概要

ユーザー向け `/tasks` 画面を作成、ついでに管理画面ヘッダーのUIも改善しました。

## 変更点

- ユーザー向けタスクページを追加
- 管理ヘッダーにプロフィールPopover・画面切替導線を追加

## 関連Issue

- なし

## スクリーンショット

| | |
| :---: | :---: |
| <img width="300" alt="localhost_3000_tasks(iPhone 14 Pro Max)" src="https://github.com/user-attachments/assets/d8918eab-25d5-4854-a7c5-51586f494bce" /> | <img src="https://github.com/user-attachments/assets/6f7a83c4-f79d-4fcb-b22b-2c000725f63a" width="300" /> |
| <img src="https://github.com/user-attachments/assets/51ae6dcc-c27f-463f-9772-76e451545500" width="300" /> | <img src="https://github.com/user-attachments/assets/06fb18fd-df62-4e57-bd59-369a4ad141c6" width="300" /> |

## 動作確認手順

1. ログイン後、`/tasks` でフィルタ・詳細表示・ステータス更新を確認
(ユーザー・指揮者・管理者で操作可能な部分が異なるので注意！)

- ユーザーはステータス・備考の変更不可
- 指揮者はステータスのみ変更可
- 管理者はステータス・備考の変更可能

3. `/admin/tasks` でヘッダーPopover表示・画面切替リンク・ログアウト導線を確認

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nutfes/goods-go/pull/28" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
