### PR TITLE
Feat/admin places

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: React Doctor
         id: react_doctor
-        uses: millionco/react-doctor@ec4a41fd827c29d79f9b27a588cde598e054d059
+        uses: millionco/react-doctor@10bd788323bfb493cb3ee1d30d914c4684fa22e6
         with:
           directory: .
           project: goods-go

--- a/src/app/(admin)/admin/locations/page.tsx
+++ b/src/app/(admin)/admin/locations/page.tsx
@@ -1,0 +1,8 @@
+import { getAdminLocationListPageData } from "@/features/admin/locations/server/queries";
+import { LocationListPageView } from "@/features/admin/locations/ui/location-list-page-view";
+
+export default async function AdminLocationsPage() {
+  const { locations } = await getAdminLocationListPageData();
+
+  return <LocationListPageView locations={locations} />;
+}

--- a/src/components/layout/admin-header.tsx
+++ b/src/components/layout/admin-header.tsx
@@ -18,7 +18,7 @@ type AdminHeaderProps = {
 const navItems = [
   { href: "/admin/tasks", label: "タスク一覧", enabled: true },
   { href: "/admin/items", label: "物品一覧", enabled: true },
-  { href: "/admin/locations", label: "場所一覧", enabled: false },
+  { href: "/admin/locations", label: "場所一覧", enabled: true },
 ] as const;
 
 type SwitchRowProps = {

--- a/src/features/admin/locations/model/schema.ts
+++ b/src/features/admin/locations/model/schema.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+const REQUIRED_NAME_ERROR = "名前を入力してください";
+const NAME_LENGTH_ERROR = "名前は80文字以内で入力してください";
+
+export const locationFormSchema = z.object({
+  name: z
+    .string({ error: REQUIRED_NAME_ERROR })
+    .trim()
+    .min(1, { error: REQUIRED_NAME_ERROR })
+    .max(80, { error: NAME_LENGTH_ERROR }),
+});
+
+export type LocationFormInput = z.infer<typeof locationFormSchema>;

--- a/src/features/admin/locations/model/types.ts
+++ b/src/features/admin/locations/model/types.ts
@@ -1,0 +1,21 @@
+export type AdminLocation = {
+  locationId: string;
+  parentLocationId: string | null;
+  name: string;
+  depth: number;
+  children: AdminLocation[];
+};
+
+export type AdminLocationListPageData = {
+  locations: AdminLocation[];
+};
+
+export type ActionResult =
+  | {
+      ok: true;
+    }
+  | {
+      ok: false;
+      message?: string;
+      fieldErrors?: Record<string, string[]>;
+    };

--- a/src/features/admin/locations/server/actions.ts
+++ b/src/features/admin/locations/server/actions.ts
@@ -1,0 +1,209 @@
+"use server";
+
+import { refresh, revalidatePath } from "next/cache";
+import { requireAdminUser } from "@/lib/auth/guards";
+import { createClient } from "@/lib/supabase/server";
+import { type LocationFormInput, locationFormSchema } from "../model/schema";
+import type { ActionResult } from "../model/types";
+
+function normalizeFieldErrors(
+  fieldErrors: Record<string, string[] | undefined>,
+): Record<string, string[]> {
+  const normalized: Record<string, string[]> = {};
+
+  for (const [fieldName, messages] of Object.entries(fieldErrors)) {
+    if (!messages || messages.length === 0) {
+      continue;
+    }
+
+    normalized[fieldName] = messages;
+  }
+
+  return normalized;
+}
+
+function parseLocationInput(
+  input: LocationFormInput,
+): { data: LocationFormInput } | { error: ActionResult } {
+  const parsed = locationFormSchema.safeParse(input);
+
+  if (!parsed.success) {
+    return {
+      error: {
+        ok: false,
+        fieldErrors: normalizeFieldErrors(parsed.error.flatten().fieldErrors),
+      },
+    };
+  }
+
+  return { data: parsed.data };
+}
+
+function toLocationActionError(message: string): ActionResult {
+  return { ok: false, message };
+}
+
+async function getActiveLocation(locationId: string) {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("locations")
+    .select("location_id,parent_location_id,name")
+    .eq("location_id", locationId)
+    .is("deleted", null)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data;
+}
+
+async function hasActiveChildren(locationId: string): Promise<boolean> {
+  const supabase = await createClient();
+  const { count, error } = await supabase
+    .from("locations")
+    .select("location_id", { count: "exact", head: true })
+    .eq("parent_location_id", locationId)
+    .is("deleted", null);
+
+  if (error) {
+    return true;
+  }
+
+  return (count ?? 0) > 0;
+}
+
+async function isLocationUsedInActiveTasks(locationId: string): Promise<boolean> {
+  const supabase = await createClient();
+  const { count, error } = await supabase
+    .from("tasks")
+    .select("task_id", { count: "exact", head: true })
+    .or(`from_location_id.eq.${locationId},to_location_id.eq.${locationId}`)
+    .is("deleted", null);
+
+  if (error) {
+    return true;
+  }
+
+  return (count ?? 0) > 0;
+}
+
+function isDuplicateError(code?: string) {
+  return code === "23505";
+}
+
+export async function createLocationAction(
+  parentLocationId: string | null,
+  input: LocationFormInput,
+): Promise<ActionResult> {
+  await requireAdminUser();
+
+  const parsedInput = parseLocationInput(input);
+  if ("error" in parsedInput) {
+    return parsedInput.error;
+  }
+
+  if (parentLocationId) {
+    const parent = await getActiveLocation(parentLocationId);
+    if (!parent) {
+      return toLocationActionError("親となる場所が見つかりません");
+    }
+  }
+
+  const supabase = await createClient();
+  const { error } = await supabase.from("locations").insert({
+    parent_location_id: parentLocationId,
+    name: parsedInput.data.name,
+  });
+
+  if (error) {
+    if (isDuplicateError(error.code)) {
+      return toLocationActionError("すでにあるエリアです");
+    }
+
+    return toLocationActionError("場所の追加に失敗しました");
+  }
+
+  revalidatePath("/admin/locations");
+  refresh();
+  return { ok: true };
+}
+
+export async function updateLocationAction(
+  locationId: string,
+  input: LocationFormInput,
+): Promise<ActionResult> {
+  await requireAdminUser();
+
+  if (!locationId) {
+    return toLocationActionError("対象の場所が見つかりません");
+  }
+
+  const parsedInput = parseLocationInput(input);
+  if ("error" in parsedInput) {
+    return parsedInput.error;
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("locations")
+    .update({ name: parsedInput.data.name })
+    .eq("location_id", locationId)
+    .is("deleted", null)
+    .select("location_id")
+    .maybeSingle();
+
+  if (error) {
+    if (isDuplicateError(error.code)) {
+      return toLocationActionError("すでにあるエリアです");
+    }
+
+    return toLocationActionError("場所の保存に失敗しました");
+  }
+
+  if (!data) {
+    return toLocationActionError("対象の場所が見つかりません");
+  }
+
+  revalidatePath("/admin/locations");
+  refresh();
+  return { ok: true };
+}
+
+export async function deleteLocationAction(locationId: string): Promise<ActionResult> {
+  await requireAdminUser();
+
+  if (!locationId) {
+    return toLocationActionError("対象の場所が見つかりません");
+  }
+
+  if (await hasActiveChildren(locationId)) {
+    return toLocationActionError("子階層がある場所は削除できません");
+  }
+
+  if (await isLocationUsedInActiveTasks(locationId)) {
+    return toLocationActionError("タスクで使用中の場所は削除できません");
+  }
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("locations")
+    .update({ deleted: new Date().toISOString() })
+    .eq("location_id", locationId)
+    .is("deleted", null)
+    .select("location_id")
+    .maybeSingle();
+
+  if (error) {
+    return toLocationActionError("場所の削除に失敗しました");
+  }
+
+  if (!data) {
+    return toLocationActionError("対象の場所が見つかりません");
+  }
+
+  revalidatePath("/admin/locations");
+  refresh();
+  return { ok: true };
+}

--- a/src/features/admin/locations/server/queries.ts
+++ b/src/features/admin/locations/server/queries.ts
@@ -1,0 +1,56 @@
+import { requireAdminUser } from "@/lib/auth/guards";
+import { createClient } from "@/lib/supabase/server";
+import type { Tables } from "@/types/schema.gen";
+import type { AdminLocation, AdminLocationListPageData } from "../model/types";
+
+type LocationRow = Tables<"locations">;
+
+type LocationNodeSeed = Omit<AdminLocation, "depth" | "children">;
+
+function buildLocationTree(rows: LocationRow[]): AdminLocation[] {
+  const childrenByParentId = new Map<string | null, LocationNodeSeed[]>();
+
+  for (const row of rows) {
+    const node: LocationNodeSeed = {
+      locationId: row.location_id,
+      parentLocationId: row.parent_location_id,
+      name: row.name,
+    };
+
+    const siblings = childrenByParentId.get(row.parent_location_id) ?? [];
+    siblings.push(node);
+    childrenByParentId.set(row.parent_location_id, siblings);
+  }
+
+  const attachChildren = (parentId: string | null, depth: number): AdminLocation[] => {
+    const siblings = childrenByParentId.get(parentId) ?? [];
+
+    return siblings.map((node) => ({
+      ...node,
+      depth,
+      children: attachChildren(node.locationId, depth + 1),
+    }));
+  };
+
+  return attachChildren(null, 0);
+}
+
+export async function getAdminLocationListPageData(): Promise<AdminLocationListPageData> {
+  await requireAdminUser();
+
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("locations")
+    .select("location_id,parent_location_id,name")
+    .is("deleted", null)
+    .order("parent_location_id", { ascending: true, nullsFirst: true })
+    .order("name", { ascending: true });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const locations = buildLocationTree((data ?? []) as LocationRow[]);
+
+  return { locations };
+}

--- a/src/features/admin/locations/ui/location-delete-dialog.tsx
+++ b/src/features/admin/locations/ui/location-delete-dialog.tsx
@@ -44,17 +44,21 @@ export function LocationDeleteDialog({ open, location, onOpenChange }: LocationD
     setErrorMessage("");
 
     startTransition(async () => {
-      try {
-        const result = await deleteLocationAction(location.locationId);
-        if (!result.ok) {
-          setErrorMessage(result.message ?? "削除に失敗しました");
-          return;
-        }
-
-        handleOpenChange(false);
-      } catch (error) {
+      const result = await deleteLocationAction(location.locationId).catch((error: unknown) => {
         setErrorMessage(error instanceof Error ? error.message : "削除に失敗しました");
+        return null;
+      });
+
+      if (!result) {
+        return;
       }
+
+      if (!result.ok) {
+        setErrorMessage(result.message ?? "削除に失敗しました");
+        return;
+      }
+
+      handleOpenChange(false);
     });
   };
 
@@ -89,11 +93,11 @@ export function LocationDeleteDialog({ open, location, onOpenChange }: LocationD
           </AlertDialogCancel>
           <AlertDialogAction
             className="h-9 rounded-[10px] bg-[#c91111] px-6 text-sm font-normal text-white hover:bg-[#b10f0f]"
+            disabled={isPending}
+            aria-busy={isPending}
             onClick={(event) => {
               event.preventDefault();
-              if (!isPending) {
-                handleDelete();
-              }
+              handleDelete();
             }}
           >
             {isPending ? "削除中..." : "削除"}

--- a/src/features/admin/locations/ui/location-delete-dialog.tsx
+++ b/src/features/admin/locations/ui/location-delete-dialog.tsx
@@ -44,13 +44,17 @@ export function LocationDeleteDialog({ open, location, onOpenChange }: LocationD
     setErrorMessage("");
 
     startTransition(async () => {
-      const result = await deleteLocationAction(location.locationId);
-      if (!result.ok) {
-        setErrorMessage(result.message ?? "削除に失敗しました");
-        return;
-      }
+      try {
+        const result = await deleteLocationAction(location.locationId);
+        if (!result.ok) {
+          setErrorMessage(result.message ?? "削除に失敗しました");
+          return;
+        }
 
-      handleOpenChange(false);
+        handleOpenChange(false);
+      } catch (error) {
+        setErrorMessage(error instanceof Error ? error.message : "削除に失敗しました");
+      }
     });
   };
 

--- a/src/features/admin/locations/ui/location-delete-dialog.tsx
+++ b/src/features/admin/locations/ui/location-delete-dialog.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { AlertCircle } from "lucide-react";
+import { useState, useTransition } from "react";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Label } from "@/components/ui/label";
+import type { AdminLocation } from "../model/types";
+import { deleteLocationAction } from "../server/actions";
+
+type LocationDeleteDialogProps = {
+  open: boolean;
+  location: AdminLocation | null;
+  onOpenChange: (open: boolean) => void;
+};
+
+function getLabel(location: AdminLocation) {
+  return location.depth === 0 ? "エリア名" : "場所名";
+}
+
+export function LocationDeleteDialog({
+  open,
+  location,
+  onOpenChange,
+}: LocationDeleteDialogProps) {
+  const [isPending, startTransition] = useTransition();
+  const [errorMessage, setErrorMessage] = useState("");
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      setErrorMessage("");
+    }
+
+    onOpenChange(nextOpen);
+  };
+
+  if (!location) {
+    return null;
+  }
+
+  const handleDelete = () => {
+    setErrorMessage("");
+
+    startTransition(async () => {
+      const result = await deleteLocationAction(location.locationId);
+      if (!result.ok) {
+        setErrorMessage(result.message ?? "削除に失敗しました");
+        return;
+      }
+
+      handleOpenChange(false);
+    });
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={handleOpenChange}>
+      <AlertDialogContent className="max-w-[543px] gap-0 rounded-[14px] border-none p-9 shadow-[0px_25px_50px_-12px_rgba(0,0,0,0.25)]">
+        <AlertDialogTitle className="sr-only">場所の削除確認</AlertDialogTitle>
+
+        <div className="space-y-8">
+          <div className="space-y-1">
+            <Label className="text-xs font-normal text-zinc-500">{getLabel(location)}</Label>
+            <div className="flex h-[42px] items-center rounded-[10px] border border-zinc-200 bg-white px-[13px] text-base text-[#0a0a0a]">
+              {location.name}
+            </div>
+          </div>
+
+          <p className="px-6 text-center text-base font-normal text-black">この項目を削除しますか？</p>
+
+          {errorMessage ? (
+            <p className="flex items-center justify-center gap-1 text-sm text-[#c91111]">
+              <AlertCircle className="h-4 w-4" />
+              {errorMessage}
+            </p>
+          ) : null}
+        </div>
+
+        <AlertDialogFooter className="mt-8 gap-3 sm:justify-end">
+          <AlertDialogCancel className="h-9 rounded-[10px] border-none px-4 text-sm font-normal text-[#364153] shadow-none hover:bg-zinc-100 hover:text-[#364153]">
+            キャンセル
+          </AlertDialogCancel>
+          <AlertDialogAction
+            className="h-9 rounded-[10px] bg-[#c91111] px-6 text-sm font-normal text-white hover:bg-[#b10f0f]"
+            onClick={(event) => {
+              event.preventDefault();
+              if (!isPending) {
+                handleDelete();
+              }
+            }}
+          >
+            {isPending ? "削除中..." : "削除"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/features/admin/locations/ui/location-delete-dialog.tsx
+++ b/src/features/admin/locations/ui/location-delete-dialog.tsx
@@ -24,11 +24,7 @@ function getLabel(location: AdminLocation) {
   return location.depth === 0 ? "エリア名" : "場所名";
 }
 
-export function LocationDeleteDialog({
-  open,
-  location,
-  onOpenChange,
-}: LocationDeleteDialogProps) {
+export function LocationDeleteDialog({ open, location, onOpenChange }: LocationDeleteDialogProps) {
   const [isPending, startTransition] = useTransition();
   const [errorMessage, setErrorMessage] = useState("");
 
@@ -71,7 +67,9 @@ export function LocationDeleteDialog({
             </div>
           </div>
 
-          <p className="px-6 text-center text-base font-normal text-black">この項目を削除しますか？</p>
+          <p className="px-6 text-center text-base font-normal text-black">
+            この項目を削除しますか？
+          </p>
 
           {errorMessage ? (
             <p className="flex items-center justify-center gap-1 text-sm text-[#c91111]">

--- a/src/features/admin/locations/ui/location-form-dialog.tsx
+++ b/src/features/admin/locations/ui/location-form-dialog.tsx
@@ -121,9 +121,10 @@ export function LocationFormDialog({
     setSubmitError("");
 
     startTransition(async () => {
-      const result = await (mode === "create"
-        ? createLocationAction(parentLocation?.locationId ?? null, values)
-        : updateLocationAction(location?.locationId ?? "", values)
+      const result = await (
+        mode === "create"
+          ? createLocationAction(parentLocation?.locationId ?? null, values)
+          : updateLocationAction(location?.locationId ?? "", values)
       ).catch(() => {
         setSubmitError(mode === "create" ? "場所の追加に失敗しました" : "場所の保存に失敗しました");
         return null;

--- a/src/features/admin/locations/ui/location-form-dialog.tsx
+++ b/src/features/admin/locations/ui/location-form-dialog.tsx
@@ -158,8 +158,15 @@ export function LocationFormDialog({
               className="h-[42px] rounded-[10px] border-zinc-300 px-3 text-base placeholder:text-black/50"
               {...form.register("name")}
             />
-            <FieldError message={form.formState.errors.name?.message ?? submitError} />
+            <FieldError message={form.formState.errors.name?.message} />
           </div>
+
+          {submitError ? (
+            <p className="flex items-center justify-center gap-1 px-9 pb-5 text-sm text-[#c91111]">
+              <AlertCircle className="h-4 w-4" />
+              {submitError}
+            </p>
+          ) : null}
 
           <DialogFooter className="gap-3 px-9 pb-9 sm:justify-end">
             <Button

--- a/src/features/admin/locations/ui/location-form-dialog.tsx
+++ b/src/features/admin/locations/ui/location-form-dialog.tsx
@@ -5,7 +5,13 @@ import { AlertCircle } from "lucide-react";
 import { useState, useTransition } from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { type LocationFormInput, locationFormSchema } from "../model/schema";
@@ -142,10 +148,7 @@ export function LocationFormDialog({
           </DialogHeader>
 
           <div className="space-y-1 px-9 pb-5">
-            <Label
-              htmlFor="location-name"
-              className="text-sm font-normal leading-5 text-[#364153]"
-            >
+            <Label htmlFor="location-name" className="text-sm font-normal leading-5 text-[#364153]">
               {getFieldLabel(mode, reference)}
             </Label>
             <Input
@@ -173,7 +176,13 @@ export function LocationFormDialog({
               className="h-9 rounded-[10px] bg-[#0017c1] px-4 text-sm font-normal text-white hover:bg-[#0014ab]"
               disabled={isPending}
             >
-              {isPending ? (mode === "create" ? "追加中..." : "保存中...") : mode === "create" ? "追加" : "保存"}
+              {isPending
+                ? mode === "create"
+                  ? "追加中..."
+                  : "保存中..."
+                : mode === "create"
+                  ? "追加"
+                  : "保存"}
             </Button>
           </DialogFooter>
         </form>

--- a/src/features/admin/locations/ui/location-form-dialog.tsx
+++ b/src/features/admin/locations/ui/location-form-dialog.tsx
@@ -32,7 +32,7 @@ function FieldError({ message }: { message?: string }) {
   }
 
   return (
-    <p className="flex items-center gap-1 text-xs text-[#c91111]">
+    <p role="alert" aria-live="polite" className="flex items-center gap-1 text-xs text-[#c91111]">
       <AlertCircle className="h-3.5 w-3.5" />
       {message}
     </p>
@@ -121,10 +121,17 @@ export function LocationFormDialog({
     setSubmitError("");
 
     startTransition(async () => {
-      const result =
-        mode === "create"
-          ? await createLocationAction(parentLocation?.locationId ?? null, values)
-          : await updateLocationAction(location?.locationId ?? "", values);
+      const result = await (mode === "create"
+        ? createLocationAction(parentLocation?.locationId ?? null, values)
+        : updateLocationAction(location?.locationId ?? "", values)
+      ).catch(() => {
+        setSubmitError(mode === "create" ? "場所の追加に失敗しました" : "場所の保存に失敗しました");
+        return null;
+      });
+
+      if (!result) {
+        return;
+      }
 
       if (!result.ok) {
         if (result.fieldErrors) {
@@ -169,7 +176,11 @@ export function LocationFormDialog({
           </div>
 
           {submitError ? (
-            <p className="flex items-center justify-center gap-1 px-9 pb-5 text-sm text-[#c91111]">
+            <p
+              role="alert"
+              aria-live="polite"
+              className="flex items-center justify-center gap-1 px-9 pb-5 text-sm text-[#c91111]"
+            >
               <AlertCircle className="h-4 w-4" />
               {submitError}
             </p>

--- a/src/features/admin/locations/ui/location-form-dialog.tsx
+++ b/src/features/admin/locations/ui/location-form-dialog.tsx
@@ -1,0 +1,183 @@
+"use client";
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { AlertCircle } from "lucide-react";
+import { useState, useTransition } from "react";
+import { useForm } from "react-hook-form";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { type LocationFormInput, locationFormSchema } from "../model/schema";
+import type { AdminLocation } from "../model/types";
+import { createLocationAction, updateLocationAction } from "../server/actions";
+
+type LocationFormDialogProps = {
+  mode: "create" | "edit";
+  open: boolean;
+  location?: AdminLocation | null;
+  parentLocation?: AdminLocation | null;
+  onOpenChange: (open: boolean) => void;
+};
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) {
+    return null;
+  }
+
+  return (
+    <p className="flex items-center gap-1 text-xs text-[#c91111]">
+      <AlertCircle className="h-3.5 w-3.5" />
+      {message}
+    </p>
+  );
+}
+
+function toDefaultValues(location?: AdminLocation | null): LocationFormInput {
+  return {
+    name: location?.name ?? "",
+  };
+}
+
+function getCreateTitle(parentLocation?: AdminLocation | null) {
+  if (!parentLocation) {
+    return "新しいエリアを追加";
+  }
+
+  return `${parentLocation.name}に場所を追加`;
+}
+
+function getFieldLabel(mode: "create" | "edit", reference?: AdminLocation | null) {
+  const depth = reference?.depth ?? -1;
+
+  if (mode === "edit") {
+    return depth <= 0 ? "エリア名" : "場所名";
+  }
+
+  if (depth < 0) {
+    return "新しいエリア名";
+  }
+
+  if (depth === 0) {
+    return "新しい階名";
+  }
+
+  return "新しい場所名";
+}
+
+function getPlaceholder(parentLocation?: AdminLocation | null) {
+  if (!parentLocation) {
+    return "例: 講義棟";
+  }
+
+  if (parentLocation.depth === 0) {
+    return "1階";
+  }
+
+  return "例: 講義棟102";
+}
+
+export function LocationFormDialog({
+  mode,
+  open,
+  location,
+  parentLocation,
+  onOpenChange,
+}: LocationFormDialogProps) {
+  const [isPending, startTransition] = useTransition();
+  const [submitError, setSubmitError] = useState("");
+
+  const form = useForm<LocationFormInput>({
+    resolver: zodResolver(locationFormSchema),
+    defaultValues: toDefaultValues(location),
+  });
+
+  const reference = mode === "edit" ? location : parentLocation;
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen) {
+      form.reset(toDefaultValues(location));
+      form.clearErrors();
+      setSubmitError("");
+    }
+
+    onOpenChange(nextOpen);
+  };
+
+  const handleSubmit = form.handleSubmit((values) => {
+    setSubmitError("");
+
+    startTransition(async () => {
+      const result =
+        mode === "create"
+          ? await createLocationAction(parentLocation?.locationId ?? null, values)
+          : await updateLocationAction(location?.locationId ?? "", values);
+
+      if (!result.ok) {
+        if (result.fieldErrors) {
+          for (const [fieldName, messages] of Object.entries(result.fieldErrors)) {
+            form.setError(fieldName as keyof LocationFormInput, { message: messages[0] });
+          }
+        }
+
+        setSubmitError(result.message ?? "");
+        return;
+      }
+
+      handleOpenChange(false);
+    });
+  });
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="max-w-[512px] gap-0 rounded-[14px] border-none p-0 shadow-[0px_25px_50px_-12px_rgba(0,0,0,0.25)]"
+        showCloseButton={false}
+      >
+        <form onSubmit={handleSubmit}>
+          <DialogHeader className="px-9 pt-9 pb-5">
+            <DialogTitle className="border-b border-zinc-200 pb-3 text-left text-[20px] font-normal text-[#0a0a0a]">
+              {mode === "create" ? getCreateTitle(parentLocation) : "エリアを編集"}
+            </DialogTitle>
+          </DialogHeader>
+
+          <div className="space-y-1 px-9 pb-5">
+            <Label
+              htmlFor="location-name"
+              className="text-sm font-normal leading-5 text-[#364153]"
+            >
+              {getFieldLabel(mode, reference)}
+            </Label>
+            <Input
+              id="location-name"
+              placeholder={getPlaceholder(parentLocation)}
+              autoComplete="off"
+              className="h-[42px] rounded-[10px] border-zinc-300 px-3 text-base placeholder:text-black/50"
+              {...form.register("name")}
+            />
+            <FieldError message={form.formState.errors.name?.message ?? submitError} />
+          </div>
+
+          <DialogFooter className="gap-3 px-9 pb-9 sm:justify-end">
+            <Button
+              type="button"
+              variant="ghost"
+              className="h-9 rounded-[10px] px-4 text-sm font-normal text-[#364153] hover:bg-zinc-100"
+              disabled={isPending}
+              onClick={() => handleOpenChange(false)}
+            >
+              キャンセル
+            </Button>
+            <Button
+              type="submit"
+              className="h-9 rounded-[10px] bg-[#0017c1] px-4 text-sm font-normal text-white hover:bg-[#0014ab]"
+              disabled={isPending}
+            >
+              {isPending ? (mode === "create" ? "追加中..." : "保存中...") : mode === "create" ? "追加" : "保存"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/features/admin/locations/ui/location-form-dialog.tsx
+++ b/src/features/admin/locations/ui/location-form-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { AlertCircle } from "lucide-react";
-import { useId, useState, useTransition } from "react";
+import { useId, useMemo, useState, useTransition } from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import {
@@ -53,6 +53,10 @@ function getCreateTitle(parentLocation?: AdminLocation | null) {
   return `${parentLocation.name}に場所を追加`;
 }
 
+function getEditTitle(location?: AdminLocation | null) {
+  return (location?.depth ?? 0) <= 0 ? "エリアを編集" : "場所を編集";
+}
+
 function getFieldLabel(mode: "create" | "edit", reference?: AdminLocation | null) {
   const depth = reference?.depth ?? -1;
 
@@ -93,10 +97,12 @@ export function LocationFormDialog({
   const [isPending, startTransition] = useTransition();
   const [submitError, setSubmitError] = useState("");
   const nameInputId = useId();
+  const formValues = useMemo(() => toDefaultValues(location), [location]);
 
   const form = useForm<LocationFormInput>({
     resolver: zodResolver(locationFormSchema),
-    defaultValues: toDefaultValues(location),
+    defaultValues: formValues,
+    values: formValues,
   });
 
   const reference = mode === "edit" ? location : parentLocation;
@@ -144,7 +150,7 @@ export function LocationFormDialog({
         <form onSubmit={handleSubmit}>
           <DialogHeader className="px-9 pt-9 pb-5">
             <DialogTitle className="border-b border-zinc-200 pb-3 text-left text-[20px] font-normal text-[#0a0a0a]">
-              {mode === "create" ? getCreateTitle(parentLocation) : "エリアを編集"}
+              {mode === "create" ? getCreateTitle(parentLocation) : getEditTitle(location)}
             </DialogTitle>
           </DialogHeader>
 

--- a/src/features/admin/locations/ui/location-form-dialog.tsx
+++ b/src/features/admin/locations/ui/location-form-dialog.tsx
@@ -2,7 +2,7 @@
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { AlertCircle } from "lucide-react";
-import { useState, useTransition } from "react";
+import { useId, useState, useTransition } from "react";
 import { useForm } from "react-hook-form";
 import { Button } from "@/components/ui/button";
 import {
@@ -92,6 +92,7 @@ export function LocationFormDialog({
 }: LocationFormDialogProps) {
   const [isPending, startTransition] = useTransition();
   const [submitError, setSubmitError] = useState("");
+  const nameInputId = useId();
 
   const form = useForm<LocationFormInput>({
     resolver: zodResolver(locationFormSchema),
@@ -148,11 +149,11 @@ export function LocationFormDialog({
           </DialogHeader>
 
           <div className="space-y-1 px-9 pb-5">
-            <Label htmlFor="location-name" className="text-sm font-normal leading-5 text-[#364153]">
+            <Label htmlFor={nameInputId} className="text-sm font-normal leading-5 text-[#364153]">
               {getFieldLabel(mode, reference)}
             </Label>
             <Input
-              id="location-name"
+              id={nameInputId}
               placeholder={getPlaceholder(parentLocation)}
               autoComplete="off"
               className="h-[42px] rounded-[10px] border-zinc-300 px-3 text-base placeholder:text-black/50"

--- a/src/features/admin/locations/ui/location-list-page-view.tsx
+++ b/src/features/admin/locations/ui/location-list-page-view.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { CirclePlus, FoldVertical, UnfoldVertical } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import type { AdminLocation } from "../model/types";
+import { LocationDeleteDialog } from "./location-delete-dialog";
+import { LocationFormDialog } from "./location-form-dialog";
+import { LocationTree } from "./location-tree";
+
+type LocationListPageViewProps = {
+  locations: AdminLocation[];
+};
+
+function collectExpandableIds(locations: AdminLocation[]): string[] {
+  return locations.flatMap((location) => [
+    ...(location.children.length > 0 ? [location.locationId] : []),
+    ...collectExpandableIds(location.children),
+  ]);
+}
+
+export function LocationListPageView({ locations }: LocationListPageViewProps) {
+  const expandableIds = useMemo(() => collectExpandableIds(locations), [locations]);
+  const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set(expandableIds));
+  const [createRootOpen, setCreateRootOpen] = useState(false);
+  const [parentLocation, setParentLocation] = useState<AdminLocation | null>(null);
+  const [editingLocation, setEditingLocation] = useState<AdminLocation | null>(null);
+  const [deletingLocation, setDeletingLocation] = useState<AdminLocation | null>(null);
+
+  useEffect(() => {
+    setExpandedIds(new Set(expandableIds));
+  }, [expandableIds]);
+
+  return (
+    <main className="px-6 py-6 md:px-16 md:py-8">
+      <div className="mx-auto max-w-[876px] space-y-4">
+        <h1 className="sr-only">場所一覧</h1>
+
+        <div className="flex justify-end">
+          <Button
+            type="button"
+            className="h-[52px] rounded-[10px] bg-black px-4 text-sm font-normal text-white hover:bg-zinc-800"
+            onClick={() => setCreateRootOpen(true)}
+          >
+            <CirclePlus className="h-4 w-4" />
+            エリアを追加
+          </Button>
+        </div>
+
+        <div className="flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 rounded-[10px] border-zinc-300 bg-white px-3 text-xs font-normal text-zinc-700"
+            onClick={() => setExpandedIds(new Set(expandableIds))}
+          >
+            <UnfoldVertical className="h-3.5 w-3.5" />
+            全て展開
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-8 rounded-[10px] border-zinc-300 bg-white px-3 text-xs font-normal text-zinc-700"
+            onClick={() => setExpandedIds(new Set())}
+          >
+            <FoldVertical className="h-3.5 w-3.5" />
+            折りたたむ
+          </Button>
+        </div>
+
+        <LocationTree
+          locations={locations}
+          expandedIds={expandedIds}
+          onExpandedChange={(locationId, open) => {
+            setExpandedIds((current) => {
+              const next = new Set(current);
+
+              if (open) {
+                next.add(locationId);
+              } else {
+                next.delete(locationId);
+              }
+
+              return next;
+            });
+          }}
+          onCreateChild={(location) => setParentLocation(location)}
+          onEdit={(location) => setEditingLocation(location)}
+          onDelete={(location) => setDeletingLocation(location)}
+        />
+      </div>
+
+      <LocationFormDialog
+        key={parentLocation?.locationId ?? "location-create-root"}
+        mode="create"
+        open={createRootOpen || parentLocation !== null}
+        parentLocation={parentLocation}
+        onOpenChange={(open) => {
+          if (!open) {
+            setCreateRootOpen(false);
+            setParentLocation(null);
+          }
+        }}
+      />
+
+      <LocationFormDialog
+        key={editingLocation?.locationId ?? "location-edit-empty"}
+        mode="edit"
+        open={editingLocation !== null}
+        location={editingLocation}
+        onOpenChange={(open) => {
+          if (!open) {
+            setEditingLocation(null);
+          }
+        }}
+      />
+
+      <LocationDeleteDialog
+        key={deletingLocation?.locationId ?? "location-delete-empty"}
+        open={deletingLocation !== null}
+        location={deletingLocation}
+        onOpenChange={(open) => {
+          if (!open) {
+            setDeletingLocation(null);
+          }
+        }}
+      />
+    </main>
+  );
+}

--- a/src/features/admin/locations/ui/location-list-page-view.tsx
+++ b/src/features/admin/locations/ui/location-list-page-view.tsx
@@ -28,7 +28,14 @@ export function LocationListPageView({ locations }: LocationListPageViewProps) {
   const [deletingLocation, setDeletingLocation] = useState<AdminLocation | null>(null);
 
   useEffect(() => {
-    setExpandedIds(new Set(expandableIds));
+    setExpandedIds((current) => {
+      if (current.size === 0) {
+        return new Set(expandableIds);
+      }
+
+      const allowed = new Set(expandableIds);
+      return new Set([...current].filter((id) => allowed.has(id)));
+    });
   }, [expandableIds]);
 
   return (

--- a/src/features/admin/locations/ui/location-list-page-view.tsx
+++ b/src/features/admin/locations/ui/location-list-page-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CirclePlus, FoldVertical, UnfoldVertical } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useReducer, useState } from "react";
 import { Button } from "@/components/ui/button";
 import type { AdminLocation } from "../model/types";
 import { LocationDeleteDialog } from "./location-delete-dialog";
@@ -19,24 +19,52 @@ function collectExpandableIds(locations: AdminLocation[]): string[] {
   ]);
 }
 
+type DialogState = {
+  createRootOpen: boolean;
+  parentLocation: AdminLocation | null;
+  editingLocation: AdminLocation | null;
+  deletingLocation: AdminLocation | null;
+};
+
+type DialogAction =
+  | { type: "open-create-root" }
+  | { type: "open-create-child"; location: AdminLocation }
+  | { type: "open-edit"; location: AdminLocation }
+  | { type: "open-delete"; location: AdminLocation }
+  | { type: "close-create" }
+  | { type: "close-edit" }
+  | { type: "close-delete" };
+
+const initialDialogState: DialogState = {
+  createRootOpen: false,
+  parentLocation: null,
+  editingLocation: null,
+  deletingLocation: null,
+};
+
+function dialogReducer(state: DialogState, action: DialogAction): DialogState {
+  switch (action.type) {
+    case "open-create-root":
+      return { ...state, createRootOpen: true, parentLocation: null };
+    case "open-create-child":
+      return { ...state, createRootOpen: false, parentLocation: action.location };
+    case "open-edit":
+      return { ...state, editingLocation: action.location };
+    case "open-delete":
+      return { ...state, deletingLocation: action.location };
+    case "close-create":
+      return { ...state, createRootOpen: false, parentLocation: null };
+    case "close-edit":
+      return { ...state, editingLocation: null };
+    case "close-delete":
+      return { ...state, deletingLocation: null };
+  }
+}
+
 export function LocationListPageView({ locations }: LocationListPageViewProps) {
   const expandableIds = useMemo(() => collectExpandableIds(locations), [locations]);
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set(expandableIds));
-  const [createRootOpen, setCreateRootOpen] = useState(false);
-  const [parentLocation, setParentLocation] = useState<AdminLocation | null>(null);
-  const [editingLocation, setEditingLocation] = useState<AdminLocation | null>(null);
-  const [deletingLocation, setDeletingLocation] = useState<AdminLocation | null>(null);
-
-  useEffect(() => {
-    setExpandedIds((current) => {
-      if (current.size === 0) {
-        return new Set(expandableIds);
-      }
-
-      const allowed = new Set(expandableIds);
-      return new Set([...current].filter((id) => allowed.has(id)));
-    });
-  }, [expandableIds]);
+  const [dialogState, dispatchDialog] = useReducer(dialogReducer, initialDialogState);
 
   return (
     <main className="px-6 py-6 md:px-16 md:py-8">
@@ -47,7 +75,7 @@ export function LocationListPageView({ locations }: LocationListPageViewProps) {
           <Button
             type="button"
             className="h-[52px] rounded-[10px] bg-black px-4 text-sm font-normal text-white hover:bg-zinc-800"
-            onClick={() => setCreateRootOpen(true)}
+            onClick={() => dispatchDialog({ type: "open-create-root" })}
           >
             <CirclePlus className="h-4 w-4" />
             エリアを追加
@@ -93,44 +121,43 @@ export function LocationListPageView({ locations }: LocationListPageViewProps) {
               return next;
             });
           }}
-          onCreateChild={(location) => setParentLocation(location)}
-          onEdit={(location) => setEditingLocation(location)}
-          onDelete={(location) => setDeletingLocation(location)}
+          onCreateChild={(location) => dispatchDialog({ type: "open-create-child", location })}
+          onEdit={(location) => dispatchDialog({ type: "open-edit", location })}
+          onDelete={(location) => dispatchDialog({ type: "open-delete", location })}
         />
       </div>
 
       <LocationFormDialog
-        key={parentLocation?.locationId ?? "location-create-root"}
+        key={dialogState.parentLocation?.locationId ?? "location-create-root"}
         mode="create"
-        open={createRootOpen || parentLocation !== null}
-        parentLocation={parentLocation}
+        open={dialogState.createRootOpen || dialogState.parentLocation !== null}
+        parentLocation={dialogState.parentLocation}
         onOpenChange={(open) => {
           if (!open) {
-            setCreateRootOpen(false);
-            setParentLocation(null);
+            dispatchDialog({ type: "close-create" });
           }
         }}
       />
 
       <LocationFormDialog
-        key={editingLocation?.locationId ?? "location-edit-empty"}
+        key={dialogState.editingLocation?.locationId ?? "location-edit-empty"}
         mode="edit"
-        open={editingLocation !== null}
-        location={editingLocation}
+        open={dialogState.editingLocation !== null}
+        location={dialogState.editingLocation}
         onOpenChange={(open) => {
           if (!open) {
-            setEditingLocation(null);
+            dispatchDialog({ type: "close-edit" });
           }
         }}
       />
 
       <LocationDeleteDialog
-        key={deletingLocation?.locationId ?? "location-delete-empty"}
-        open={deletingLocation !== null}
-        location={deletingLocation}
+        key={dialogState.deletingLocation?.locationId ?? "location-delete-empty"}
+        open={dialogState.deletingLocation !== null}
+        location={dialogState.deletingLocation}
         onOpenChange={(open) => {
           if (!open) {
-            setDeletingLocation(null);
+            dispatchDialog({ type: "close-delete" });
           }
         }}
       />

--- a/src/features/admin/locations/ui/location-tree.tsx
+++ b/src/features/admin/locations/ui/location-tree.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { ChevronDown, ChevronRight, Pencil, Plus, Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { cn } from "@/lib/utils";
+import type { AdminLocation } from "../model/types";
+
+type LocationTreeProps = {
+  locations: AdminLocation[];
+  expandedIds: Set<string>;
+  onExpandedChange: (locationId: string, open: boolean) => void;
+  onCreateChild: (location: AdminLocation) => void;
+  onEdit: (location: AdminLocation) => void;
+  onDelete: (location: AdminLocation) => void;
+};
+
+type LocationTreeNodeProps = Omit<LocationTreeProps, "locations"> & {
+  location: AdminLocation;
+  isNested?: boolean;
+};
+
+function canCreateChild(location: AdminLocation) {
+  return location.depth < 2;
+}
+
+function rowBackgroundClass(location: AdminLocation, hasChildren: boolean) {
+  if (location.depth === 0) {
+    return "bg-white";
+  }
+
+  if (hasChildren) {
+    return "bg-[#f3f4f6]";
+  }
+
+  return "bg-white";
+}
+
+function LocationTreeNode({
+  location,
+  expandedIds,
+  onExpandedChange,
+  onCreateChild,
+  onEdit,
+  onDelete,
+  isNested = false,
+}: LocationTreeNodeProps) {
+  const hasChildren = location.children.length > 0;
+  const isExpanded = hasChildren ? expandedIds.has(location.locationId) : false;
+
+  return (
+    <div className={cn("relative", isNested && "pl-8")}>
+      <Collapsible
+        open={isExpanded}
+        onOpenChange={(open) => onExpandedChange(location.locationId, open)}
+      >
+        <div
+          className={cn(
+            "flex min-h-14 items-center justify-between border-b px-4 py-1",
+            location.depth === 0 ? "border-black" : "border-zinc-300",
+            rowBackgroundClass(location, hasChildren),
+          )}
+        >
+          <div className="min-w-0 flex-1">
+            {hasChildren ? (
+              <CollapsibleTrigger asChild>
+                <button
+                  type="button"
+                  className="flex min-h-11 items-center gap-3 text-left text-[18px] font-normal text-[#0a0a0a] outline-none focus-visible:ring-2 focus-visible:ring-zinc-400"
+                >
+                  {isExpanded ? (
+                    <ChevronDown className="h-4 w-4 shrink-0" />
+                  ) : (
+                    <ChevronRight className="h-4 w-4 shrink-0" />
+                  )}
+                  <span className="truncate">{location.name}</span>
+                </button>
+              </CollapsibleTrigger>
+            ) : (
+              <div className="flex min-h-11 items-center gap-3 pl-7 text-[18px] font-normal text-[#0a0a0a]">
+                <span className="truncate">{location.name}</span>
+              </div>
+            )}
+          </div>
+
+          <div className="flex items-center">
+            {canCreateChild(location) ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className="h-11 w-11 rounded-md text-black hover:bg-zinc-200"
+                aria-label={`${location.name}の配下に場所を追加`}
+                onClick={() => onCreateChild(location)}
+              >
+                <Plus className="h-5 w-5" />
+              </Button>
+            ) : (
+              <div className="w-11" aria-hidden="true" />
+            )}
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="h-11 w-11 rounded-md hover:bg-zinc-200"
+              aria-label={`${location.name}を編集`}
+              onClick={() => onEdit(location)}
+            >
+              <Pencil className="h-5 w-5 text-[#70b64d]" />
+            </Button>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-sm"
+              className="h-11 w-11 rounded-md hover:bg-zinc-200"
+              aria-label={`${location.name}を削除`}
+              onClick={() => onDelete(location)}
+            >
+              <Trash2 className="h-5 w-5 text-[#ff1f1f]" />
+            </Button>
+          </div>
+        </div>
+
+        {hasChildren ? (
+          <CollapsibleContent>
+            <div className="ml-6 border-l border-zinc-300">
+              {location.children.map((child) => (
+                <LocationTreeNode
+                  key={child.locationId}
+                  location={child}
+                  expandedIds={expandedIds}
+                  onExpandedChange={onExpandedChange}
+                  onCreateChild={onCreateChild}
+                  onEdit={onEdit}
+                  onDelete={onDelete}
+                  isNested
+                />
+              ))}
+            </div>
+          </CollapsibleContent>
+        ) : null}
+      </Collapsible>
+    </div>
+  );
+}
+
+export function LocationTree({
+  locations,
+  expandedIds,
+  onExpandedChange,
+  onCreateChild,
+  onEdit,
+  onDelete,
+}: LocationTreeProps) {
+  return (
+    <div className="space-y-0">
+      {locations.map((location) => (
+        <LocationTreeNode
+          key={location.locationId}
+          location={location}
+          expandedIds={expandedIds}
+          onExpandedChange={onExpandedChange}
+          onCreateChild={onCreateChild}
+          onEdit={onEdit}
+          onDelete={onDelete}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/features/admin/locations/ui/location-tree.tsx
+++ b/src/features/admin/locations/ui/location-tree.tsx
@@ -32,10 +32,6 @@ function rowBackgroundClass(hasChildren: boolean, isExpanded: boolean) {
   return "bg-transparent";
 }
 
-function rowBackgroundClass(location: AdminLocation, hasChildren: boolean) {
-  return "bg-white";
-}
-
 function LocationTreeNode({
   location,
   expandedIds,

--- a/src/features/admin/locations/ui/location-tree.tsx
+++ b/src/features/admin/locations/ui/location-tree.tsx
@@ -24,6 +24,14 @@ function canCreateChild(location: AdminLocation) {
   return location.depth < 2;
 }
 
+function rowBackgroundClass(hasChildren: boolean, isExpanded: boolean) {
+  if (hasChildren && isExpanded) {
+    return "bg-[#f3f4f6]";
+  }
+
+  return "bg-transparent";
+}
+
 function rowBackgroundClass(location: AdminLocation, hasChildren: boolean) {
   return "bg-white";
 }
@@ -50,7 +58,7 @@ function LocationTreeNode({
           className={cn(
             "flex min-h-14 items-center justify-between border-b px-4 py-1",
             location.depth === 0 ? "border-black" : "border-zinc-300",
-            rowBackgroundClass(location, hasChildren),
+            rowBackgroundClass(hasChildren, isExpanded),
           )}
         >
           <div className="min-w-0 flex-1">

--- a/src/features/admin/locations/ui/location-tree.tsx
+++ b/src/features/admin/locations/ui/location-tree.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ChevronDown, ChevronRight, Pencil, Plus, Trash2 } from "lucide-react";
+import { ChevronRight, Pencil, Plus, Trash2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
@@ -52,9 +52,10 @@ function LocationTreeNode({
       >
         <div
           className={cn(
-            "flex min-h-14 items-center justify-between border-b px-4 py-1",
+            "flex min-h-14 items-center justify-between border-b px-4 py-1 transition-colors duration-200 ease-out motion-reduce:transition-none",
             location.depth === 0 ? "border-black" : "border-zinc-300",
             rowBackgroundClass(hasChildren, isExpanded),
+            !isExpanded && "hover:bg-black/[0.02]",
           )}
         >
           <div className="min-w-0 flex-1">
@@ -62,13 +63,14 @@ function LocationTreeNode({
               <CollapsibleTrigger asChild>
                 <button
                   type="button"
-                  className="flex min-h-11 items-center gap-3 text-left text-[18px] font-normal text-[#0a0a0a] outline-none focus-visible:ring-2 focus-visible:ring-zinc-400"
+                  className="group flex min-h-11 items-center gap-3 text-left text-[18px] font-normal text-[#0a0a0a] outline-none focus-visible:ring-2 focus-visible:ring-zinc-400"
                 >
-                  {isExpanded ? (
-                    <ChevronDown className="h-4 w-4 shrink-0" />
-                  ) : (
-                    <ChevronRight className="h-4 w-4 shrink-0" />
-                  )}
+                  <ChevronRight
+                    className={cn(
+                      "h-4 w-4 shrink-0 transition-transform duration-200 ease-out motion-reduce:transition-none",
+                      isExpanded && "rotate-90",
+                    )}
+                  />
                   <span className="truncate">{location.name}</span>
                 </button>
               </CollapsibleTrigger>
@@ -85,7 +87,7 @@ function LocationTreeNode({
                 type="button"
                 variant="ghost"
                 size="icon-sm"
-                className="h-11 w-11 rounded-md text-black hover:bg-zinc-200"
+                className="h-11 w-11 rounded-md text-black transition-colors duration-200 hover:bg-black/5"
                 aria-label={`${location.name}の配下に場所を追加`}
                 onClick={() => onCreateChild(location)}
               >
@@ -98,7 +100,7 @@ function LocationTreeNode({
               type="button"
               variant="ghost"
               size="icon-sm"
-              className="h-11 w-11 rounded-md hover:bg-zinc-200"
+              className="h-11 w-11 rounded-md transition-colors duration-200 hover:bg-black/5"
               aria-label={`${location.name}を編集`}
               onClick={() => onEdit(location)}
             >
@@ -108,7 +110,7 @@ function LocationTreeNode({
               type="button"
               variant="ghost"
               size="icon-sm"
-              className="h-11 w-11 rounded-md hover:bg-zinc-200"
+              className="h-11 w-11 rounded-md transition-colors duration-200 hover:bg-black/5"
               aria-label={`${location.name}を削除`}
               onClick={() => onDelete(location)}
             >
@@ -118,7 +120,7 @@ function LocationTreeNode({
         </div>
 
         {hasChildren ? (
-          <CollapsibleContent>
+          <CollapsibleContent className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden">
             <div className="ml-6 border-l border-zinc-300">
               {location.children.map((child) => (
                 <LocationTreeNode

--- a/src/features/admin/locations/ui/location-tree.tsx
+++ b/src/features/admin/locations/ui/location-tree.tsx
@@ -25,14 +25,6 @@ function canCreateChild(location: AdminLocation) {
 }
 
 function rowBackgroundClass(location: AdminLocation, hasChildren: boolean) {
-  if (location.depth === 0) {
-    return "bg-white";
-  }
-
-  if (hasChildren) {
-    return "bg-[#f3f4f6]";
-  }
-
   return "bg-white";
 }
 

--- a/src/features/admin/locations/ui/location-tree.tsx
+++ b/src/features/admin/locations/ui/location-tree.tsx
@@ -55,7 +55,6 @@ function LocationTreeNode({
             "flex min-h-14 items-center justify-between border-b px-4 py-1 transition-colors duration-200 ease-out motion-reduce:transition-none",
             location.depth === 0 ? "border-black" : "border-zinc-300",
             rowBackgroundClass(hasChildren, isExpanded),
-            !isExpanded && "hover:bg-black/[0.02]",
           )}
         >
           <div className="min-w-0 flex-1">
@@ -65,12 +64,19 @@ function LocationTreeNode({
                   type="button"
                   className="group flex min-h-11 items-center gap-3 text-left text-[18px] font-normal text-[#0a0a0a] outline-none focus-visible:ring-2 focus-visible:ring-zinc-400"
                 >
-                  <ChevronRight
+                  <span
                     className={cn(
-                      "h-4 w-4 shrink-0 transition-transform duration-200 ease-out motion-reduce:transition-none",
-                      isExpanded && "rotate-90",
+                      "flex size-7 shrink-0 items-center justify-center rounded-full transition-colors duration-200 ease-out motion-reduce:transition-none",
+                      isExpanded ? "bg-black/5" : "bg-transparent group-hover:bg-black/5",
                     )}
-                  />
+                  >
+                    <ChevronRight
+                      className={cn(
+                        "h-4 w-4 shrink-0 transition-transform duration-300 ease-out motion-reduce:transition-none",
+                        isExpanded && "rotate-90",
+                      )}
+                    />
+                  </span>
                   <span className="truncate">{location.name}</span>
                 </button>
               </CollapsibleTrigger>
@@ -120,7 +126,14 @@ function LocationTreeNode({
         </div>
 
         {hasChildren ? (
-          <CollapsibleContent className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden">
+          <CollapsibleContent
+            className={cn(
+              "overflow-hidden",
+              "data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down",
+              "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+              "data-[state=open]:slide-in-from-top-1 data-[state=closed]:slide-out-to-top-1",
+            )}
+          >
             <div className="ml-6 border-l border-zinc-300">
               {location.children.map((child) => (
                 <LocationTreeNode


### PR DESCRIPTION
## 概要
Figma の「場所一覧」デザインをもとに、管理画面の `/admin/locations` を追加実装しました。

あわせて、場所一覧タブの有効化、階層ツリー表示、追加・編集・削除ダイアログ、開閉アニメーションなど、場所管理に必要な UI と基本 CRUD を追加しています。

## スクリーンショット等

<img width="1113" height="878" alt="image" src="https://github.com/user-attachments/assets/ec491c27-67e5-4b86-8c20-40ad57d1cb9a" />

## 変更内容
- 管理画面に `/admin/locations` を追加
- ヘッダーの「場所一覧」タブを有効化
- `locations` テーブルを使った一覧取得処理を追加
- 場所の追加・編集・削除 action を追加
- 親子関係を持つ場所を再帰ツリーで表示
- 「全て展開」「折りたたむ」操作を追加
- Figma に寄せて、階層線・背景色・開閉アニメーションを調整
- 追加・編集・削除ダイアログを実装
- 子階層がある場所や、タスクで使用中の場所は削除できないよう制御

## 確認してほしい点
- 場所一覧の見た目が Figma の意図に沿っているか
- 階層ツリーの開閉操作が分かりやすいか
- 追加・編集・削除の導線が自然か
- 削除不可条件の文言や UX に違和感がないか



## 補足

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/nutfes/goods-go/pull/31" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin locations management page with hierarchical tree, expand/collapse, and dialog-driven create/edit/delete flows.
  * Client-side validation for location names (required, 1–80 chars) with inline and server-reported error messages.
  * Admin listing and CRUD operations that prevent conflicts (duplicate names, child/usage blocks) and automatically refresh the UI after changes.
* **Chores**
  * CI workflow: updated pinned action reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->