### PR TITLE
[fix] 場所一覧デザインをFigmaに合わせる

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "lint:fix": "oxlint --fix",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
-    "preinstall": "npx only-allow pnpm"
+    "preinstall": "npx only-allow pnpm",
+    "supabase": "supabase"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -41,13 +42,11 @@
     "@radix-ui/react-toggle": "^1.1.10",
     "@radix-ui/react-toggle-group": "^1.1.11",
     "@radix-ui/react-tooltip": "^1.2.8",
-    "@radix-ui/react-visually-hidden": "^1.2.4",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
-    "date-fns": "^4.1.0",
     "embla-carousel-react": "^8.6.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.562.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,9 +89,6 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: ^1.2.8
         version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      '@radix-ui/react-visually-hidden':
-        specifier: ^1.2.4
-        version: 1.2.4(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@supabase/ssr':
         specifier: ^0.8.0
         version: 0.8.0(@supabase/supabase-js@2.95.3)
@@ -107,9 +104,6 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      date-fns:
-        specifier: ^4.1.0
-        version: 4.1.0
       embla-carousel-react:
         specifier: ^8.6.0
         version: 8.6.0(react@19.2.3)
@@ -1306,19 +1300,6 @@ packages:
 
   '@radix-ui/react-visually-hidden@1.2.3':
     resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-visually-hidden@1.2.4':
-    resolution: {integrity: sha512-kaeiyGCe844dkb9AVF+rb4yTyb1LiLN/e3es3nLiRyN4dC8AduBYPMnnNlDjX2VDOcvDEiPnRNMJeWCfsX0txg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3099,15 +3080,6 @@ snapshots:
   '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
-      react: 19.2.3
-      react-dom: 19.2.3(react@19.2.3)
-    optionalDependencies:
-      '@types/react': 19.2.8
-      '@types/react-dom': 19.2.3(@types/react@19.2.8)
-
-  '@radix-ui/react-visually-hidden@1.2.4(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.8))(@types/react@19.2.8)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,9 @@
 packages:
   - .
 
+minimumReleaseAge: 10080
+trustPolicy: no-downgrade
+
 ignoredBuiltDependencies:
   - sharp
   - unrs-resolver

--- a/src/features/admin/items/ui/item-delete-dialog.tsx
+++ b/src/features/admin/items/ui/item-delete-dialog.tsx
@@ -65,7 +65,7 @@ export function ItemDeleteDialog({ open, item, onOpenChange }: ItemDeleteDialogP
 
           {errorMessage ? (
             <p className="flex items-center justify-center gap-1 text-sm text-red-600">
-              <AlertCircle className="h-4 w-4" />
+              <AlertCircle className="size-4" />
               {errorMessage}
             </p>
           ) : null}

--- a/src/features/admin/items/ui/item-form-dialog.tsx
+++ b/src/features/admin/items/ui/item-form-dialog.tsx
@@ -32,7 +32,7 @@ function FieldError({ message }: { message?: string }) {
 
   return (
     <p className="mt-1 flex items-center gap-1 text-xs text-red-600">
-      <AlertCircle className="h-3.5 w-3.5" />
+      <AlertCircle className="size-3.5" />
       {message}
     </p>
   );
@@ -98,7 +98,7 @@ export function ItemFormDialog({ mode, open, item, onOpenChange }: ItemFormDialo
         <form onSubmit={handleSubmit} className="space-y-5">
           <section>
             <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold">
-              <Package className="h-4 w-4" />
+              <Package className="size-4" />
               物品情報
             </h3>
 
@@ -118,7 +118,7 @@ export function ItemFormDialog({ mode, open, item, onOpenChange }: ItemFormDialo
 
           {submitError ? (
             <p className="flex items-center gap-1 text-sm text-red-600">
-              <AlertCircle className="h-4 w-4" />
+              <AlertCircle className="size-4" />
               {submitError}
             </p>
           ) : null}

--- a/src/features/admin/items/ui/item-list-page-view.tsx
+++ b/src/features/admin/items/ui/item-list-page-view.tsx
@@ -30,7 +30,7 @@ export function ItemListPageView({ items }: ItemListPageViewProps) {
             className="bg-zinc-950 text-white hover:bg-zinc-800"
             onClick={() => setCreateOpen(true)}
           >
-            <CirclePlus className="h-4 w-4" />
+            <CirclePlus className="size-4" />
             物品を追加
           </Button>
         </div>

--- a/src/features/admin/items/ui/item-table.tsx
+++ b/src/features/admin/items/ui/item-table.tsx
@@ -61,7 +61,7 @@ export function ItemTable({ items, onEdit, onDelete }: ItemTableProps) {
                   onClick={() => onEdit(item)}
                   aria-label="編集"
                 >
-                  <Pencil className="h-4 w-4 text-green-600" aria-hidden="true" />
+                  <Pencil className="size-4 text-green-600" aria-hidden="true" />
                 </Button>
               </TableCell>
               <TableCell className="px-2 text-center">
@@ -72,7 +72,7 @@ export function ItemTable({ items, onEdit, onDelete }: ItemTableProps) {
                   onClick={() => onDelete(item)}
                   aria-label="削除"
                 >
-                  <Trash2 className="h-4 w-4 text-red-600" aria-hidden="true" />
+                  <Trash2 className="size-4 text-red-600" aria-hidden="true" />
                 </Button>
               </TableCell>
             </TableRow>

--- a/src/features/admin/locations/ui/location-delete-dialog.tsx
+++ b/src/features/admin/locations/ui/location-delete-dialog.tsx
@@ -81,7 +81,7 @@ export function LocationDeleteDialog({ open, location, onOpenChange }: LocationD
 
           {errorMessage ? (
             <p className="flex items-center justify-center gap-1 text-sm text-[#c91111]">
-              <AlertCircle className="h-4 w-4" />
+              <AlertCircle className="size-4" />
               {errorMessage}
             </p>
           ) : null}

--- a/src/features/admin/locations/ui/location-form-dialog.tsx
+++ b/src/features/admin/locations/ui/location-form-dialog.tsx
@@ -33,7 +33,7 @@ function FieldError({ message }: { message?: string }) {
 
   return (
     <p role="alert" aria-live="polite" className="flex items-center gap-1 text-xs text-[#c91111]">
-      <AlertCircle className="h-3.5 w-3.5" />
+      <AlertCircle className="size-3.5" />
       {message}
     </p>
   );
@@ -182,7 +182,7 @@ export function LocationFormDialog({
               aria-live="polite"
               className="flex items-center justify-center gap-1 px-9 pb-5 text-sm text-[#c91111]"
             >
-              <AlertCircle className="h-4 w-4" />
+              <AlertCircle className="size-4" />
               {submitError}
             </p>
           ) : null}

--- a/src/features/admin/locations/ui/location-list-page-view.tsx
+++ b/src/features/admin/locations/ui/location-list-page-view.tsx
@@ -77,7 +77,7 @@ export function LocationListPageView({ locations }: LocationListPageViewProps) {
             className="bg-zinc-950 text-white hover:bg-zinc-800"
             onClick={() => dispatchDialog({ type: "open-create-root" })}
           >
-            <CirclePlus className="h-4 w-4" />
+            <CirclePlus className="size-4" />
             エリアを追加
           </Button>
         </div>

--- a/src/features/admin/locations/ui/location-list-page-view.tsx
+++ b/src/features/admin/locations/ui/location-list-page-view.tsx
@@ -67,17 +67,17 @@ export function LocationListPageView({ locations }: LocationListPageViewProps) {
   const [dialogState, dispatchDialog] = useReducer(dialogReducer, initialDialogState);
 
   return (
-    <main className="px-6 py-6 md:px-16 md:py-8">
-      <div className="mx-auto max-w-[876px] space-y-4">
+    <main className="min-h-[calc(100vh-60px)] bg-[#f3f4f6] px-6 py-8 md:px-16">
+      <div className="mx-auto flex max-w-[876px] flex-col gap-4">
         <h1 className="sr-only">場所一覧</h1>
 
         <div className="flex justify-end">
           <Button
             type="button"
-            className="h-[52px] rounded-[10px] bg-zinc-950 px-4 text-sm font-normal text-white hover:bg-zinc-800"
+            className="h-[52px] rounded-lg bg-[#171717] px-3 text-sm font-normal text-[#fafafa] shadow-[0_1px_1px_rgba(0,0,0,0.1)] hover:bg-zinc-800"
             onClick={() => dispatchDialog({ type: "open-create-root" })}
           >
-            <CirclePlus className="h-4 w-4" />
+            <CirclePlus className="size-5" />
             エリアを追加
           </Button>
         </div>
@@ -87,20 +87,20 @@ export function LocationListPageView({ locations }: LocationListPageViewProps) {
             type="button"
             variant="outline"
             size="sm"
-            className="h-8 rounded-[10px] border-zinc-300 bg-white px-3 text-xs font-normal text-zinc-700"
+            className="h-8 rounded-[10px] border-[#e5e7eb] bg-white px-3 text-xs font-normal text-black shadow-[0_1px_1px_rgba(0,0,0,0.25)] hover:bg-white/90"
             onClick={() => setExpandedIds(new Set(expandableIds))}
           >
-            <UnfoldVertical className="h-3.5 w-3.5" />
+            <UnfoldVertical className="size-3" />
             全て展開
           </Button>
           <Button
             type="button"
             variant="outline"
             size="sm"
-            className="h-8 rounded-[10px] border-zinc-300 bg-white px-3 text-xs font-normal text-zinc-700"
+            className="h-8 rounded-[10px] border-[#e5e7eb] bg-white px-3 text-xs font-normal text-black shadow-[0_1px_1px_rgba(0,0,0,0.25)] hover:bg-white/90"
             onClick={() => setExpandedIds(new Set())}
           >
-            <FoldVertical className="h-3.5 w-3.5" />
+            <FoldVertical className="size-3" />
             折りたたむ
           </Button>
         </div>

--- a/src/features/admin/locations/ui/location-list-page-view.tsx
+++ b/src/features/admin/locations/ui/location-list-page-view.tsx
@@ -74,10 +74,10 @@ export function LocationListPageView({ locations }: LocationListPageViewProps) {
         <div className="flex justify-end">
           <Button
             type="button"
-            className="h-[52px] rounded-lg bg-[#171717] px-3 text-sm font-normal text-[#fafafa] shadow-[0_1px_1px_rgba(0,0,0,0.1)] hover:bg-zinc-800"
+            className="bg-zinc-950 text-white hover:bg-zinc-800"
             onClick={() => dispatchDialog({ type: "open-create-root" })}
           >
-            <CirclePlus className="size-5" />
+            <CirclePlus className="h-4 w-4" />
             エリアを追加
           </Button>
         </div>

--- a/src/features/admin/locations/ui/location-tree.tsx
+++ b/src/features/admin/locations/ui/location-tree.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { ChevronRight, Pencil, Plus, Trash2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Pencil, Plus, Trash2 } from "lucide-react";
+import type { CSSProperties } from "react";
 import { Button } from "@/components/ui/button";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { cn } from "@/lib/utils";
@@ -17,19 +18,14 @@ type LocationTreeProps = {
 
 type LocationTreeNodeProps = Omit<LocationTreeProps, "locations"> & {
   location: AdminLocation;
-  isNested?: boolean;
+};
+
+type LocationTreeLineStyle = CSSProperties & {
+  "--location-tree-line-left": string;
 };
 
 function canCreateChild(location: AdminLocation) {
   return location.depth < 2;
-}
-
-function rowBackgroundClass(hasChildren: boolean, isExpanded: boolean) {
-  if (hasChildren && isExpanded) {
-    return "bg-[#f3f4f6]";
-  }
-
-  return "bg-transparent";
 }
 
 function LocationTreeNode({
@@ -39,49 +35,40 @@ function LocationTreeNode({
   onCreateChild,
   onEdit,
   onDelete,
-  isNested = false,
 }: LocationTreeNodeProps) {
   const hasChildren = location.children.length > 0;
   const isExpanded = hasChildren ? expandedIds.has(location.locationId) : false;
+  const indent = location.depth * 56;
 
   return (
-    <div className={cn("relative", isNested && "pl-8")}>
+    <div className="relative">
       <Collapsible
         open={isExpanded}
         onOpenChange={(open) => onExpandedChange(location.locationId, open)}
       >
         <div
-          className={cn(
-            "flex min-h-14 items-center justify-between border-b px-4 py-1 transition-colors duration-200 ease-out motion-reduce:transition-none",
-            location.depth === 0 ? "border-black" : "border-zinc-300",
-            rowBackgroundClass(hasChildren, isExpanded),
-          )}
+          className="flex min-h-14 items-center justify-between rounded-lg border-b border-[#e5e5e5] bg-white px-4 py-1 transition-colors duration-200 ease-out motion-reduce:transition-none"
+          style={{ marginLeft: indent }}
         >
           <div className="min-w-0 flex-1">
             {hasChildren ? (
               <CollapsibleTrigger asChild>
                 <button
                   type="button"
-                  className="group flex min-h-11 items-center gap-3 text-left text-[18px] font-normal text-[#0a0a0a] outline-none focus-visible:ring-2 focus-visible:ring-zinc-400"
+                  className="group flex min-h-11 items-center gap-2 text-left text-[20px] leading-5 font-normal text-[#0a0a0a] outline-none focus-visible:ring-2 focus-visible:ring-zinc-400"
                 >
-                  <span
-                    className={cn(
-                      "flex size-7 shrink-0 items-center justify-center rounded-full transition-colors duration-200 ease-out motion-reduce:transition-none",
-                      isExpanded ? "bg-black/5" : "bg-transparent group-hover:bg-black/5",
+                  <span className="flex size-4 shrink-0 items-center justify-center">
+                    {isExpanded ? (
+                      <ChevronDown className="size-4 shrink-0" />
+                    ) : (
+                      <ChevronRight className="size-4 shrink-0" />
                     )}
-                  >
-                    <ChevronRight
-                      className={cn(
-                        "h-4 w-4 shrink-0 transition-transform duration-300 ease-out motion-reduce:transition-none",
-                        isExpanded && "rotate-90",
-                      )}
-                    />
                   </span>
                   <span className="truncate">{location.name}</span>
                 </button>
               </CollapsibleTrigger>
             ) : (
-              <div className="flex min-h-11 items-center gap-3 pl-7 text-[18px] font-normal text-[#0a0a0a]">
+              <div className="flex min-h-11 items-center text-[20px] leading-5 font-normal text-[#0a0a0a]">
                 <span className="truncate">{location.name}</span>
               </div>
             )}
@@ -93,34 +80,34 @@ function LocationTreeNode({
                 type="button"
                 variant="ghost"
                 size="icon-sm"
-                className="h-11 w-11 rounded-md text-black transition-colors duration-200 hover:bg-black/5"
+                className="size-12 rounded-md text-black transition-colors duration-200 hover:bg-black/5"
                 aria-label={`${location.name}の配下に場所を追加`}
                 onClick={() => onCreateChild(location)}
               >
-                <Plus className="h-5 w-5" />
+                <Plus className="size-5" />
               </Button>
             ) : (
-              <div className="w-11" aria-hidden="true" />
+              <div className="w-12" aria-hidden="true" />
             )}
             <Button
               type="button"
               variant="ghost"
               size="icon-sm"
-              className="h-11 w-11 rounded-md transition-colors duration-200 hover:bg-black/5"
+              className="size-12 rounded-md transition-colors duration-200 hover:bg-black/5"
               aria-label={`${location.name}を編集`}
               onClick={() => onEdit(location)}
             >
-              <Pencil className="h-5 w-5 text-[#70b64d]" />
+              <Pencil className="size-5 text-[#70b64d]" />
             </Button>
             <Button
               type="button"
               variant="ghost"
               size="icon-sm"
-              className="h-11 w-11 rounded-md transition-colors duration-200 hover:bg-black/5"
+              className="size-12 rounded-md transition-colors duration-200 hover:bg-black/5"
               aria-label={`${location.name}を削除`}
               onClick={() => onDelete(location)}
             >
-              <Trash2 className="h-5 w-5 text-[#ff1f1f]" />
+              <Trash2 className="size-5 text-[#ff1f1f]" />
             </Button>
           </div>
         </div>
@@ -134,7 +121,14 @@ function LocationTreeNode({
               "data-[state=open]:slide-in-from-top-1 data-[state=closed]:slide-out-to-top-1",
             )}
           >
-            <div className="ml-6 border-l border-zinc-300">
+            <div
+              className={cn(
+                "relative",
+                isExpanded &&
+                  "before:absolute before:top-3 before:bottom-3 before:left-[var(--location-tree-line-left)] before:w-px before:bg-[#d1d5db]",
+              )}
+              style={{ "--location-tree-line-left": `${indent + 24}px` } as LocationTreeLineStyle}
+            >
               {location.children.map((child) => (
                 <LocationTreeNode
                   key={child.locationId}
@@ -144,7 +138,6 @@ function LocationTreeNode({
                   onCreateChild={onCreateChild}
                   onEdit={onEdit}
                   onDelete={onDelete}
-                  isNested
                 />
               ))}
             </div>
@@ -164,7 +157,7 @@ export function LocationTree({
   onDelete,
 }: LocationTreeProps) {
   return (
-    <div className="space-y-0">
+    <div>
       {locations.map((location) => (
         <LocationTreeNode
           key={location.locationId}

--- a/src/features/admin/tasks/ui/task-delete-dialog.tsx
+++ b/src/features/admin/tasks/ui/task-delete-dialog.tsx
@@ -55,7 +55,7 @@ export function TaskDeleteDialog({ open, task, onOpenChange }: TaskDeleteDialogP
               </div>
             </div>
             <div className="mb-3 text-zinc-400">
-              <Triangle className="h-4 w-4 rotate-90 fill-current" />
+              <Triangle className="size-4 rotate-90 fill-current" />
             </div>
             <div className="space-y-1.5">
               <Label className="text-xs text-zinc-500 font-normal">To (搬入先)</Label>
@@ -76,7 +76,7 @@ export function TaskDeleteDialog({ open, task, onOpenChange }: TaskDeleteDialogP
 
           {errorMessage ? (
             <p className="flex items-center justify-center gap-1 text-sm text-red-600">
-              <AlertCircle className="h-4 w-4" />
+              <AlertCircle className="size-4" />
               {errorMessage}
             </p>
           ) : null}

--- a/src/features/admin/tasks/ui/task-filter-bar.tsx
+++ b/src/features/admin/tasks/ui/task-filter-bar.tsx
@@ -143,28 +143,28 @@ export function TaskFilterBar({ filters, filterOptions, onChange }: TaskFilterBa
       ? {
           key: "itemId" as const,
           label: itemLabel,
-          icon: <Package className="h-3 w-3" aria-hidden="true" />,
+          icon: <Package className="size-3" aria-hidden="true" />,
         }
       : null,
     leaderLabel
       ? {
           key: "leaderUserId" as const,
           label: leaderLabel,
-          icon: <User className="h-3 w-3" aria-hidden="true" />,
+          icon: <User className="size-3" aria-hidden="true" />,
         }
       : null,
     fromLabel
       ? {
           key: "fromLocationId" as const,
           label: `From : ${fromLabel}`,
-          icon: <MapPin className="h-3 w-3" aria-hidden="true" />,
+          icon: <MapPin className="size-3" aria-hidden="true" />,
         }
       : null,
     toLabel
       ? {
           key: "toLocationId" as const,
           label: `To : ${toLabel}`,
-          icon: <MapPin className="h-3 w-3" aria-hidden="true" />,
+          icon: <MapPin className="size-3" aria-hidden="true" />,
         }
       : null,
   ].filter((tag) => tag !== null);
@@ -173,7 +173,7 @@ export function TaskFilterBar({ filters, filterOptions, onChange }: TaskFilterBa
     <section className="space-y-4 rounded-[10px] border bg-white p-4 shadow-sm">
       <div className="flex flex-wrap items-center gap-3">
         <div className="flex items-center gap-2">
-          <Calendar className="h-4 w-4 text-zinc-600" aria-hidden="true" />
+          <Calendar className="size-4 text-zinc-600" aria-hidden="true" />
           <span className="text-sm font-medium text-zinc-700">日程</span>
           <ToggleGroup
             type="single"
@@ -203,7 +203,7 @@ export function TaskFilterBar({ filters, filterOptions, onChange }: TaskFilterBa
         <div className="mx-2 h-6 w-px bg-zinc-200" />
 
         <div className="flex items-center gap-2">
-          <ListTodo className="h-4 w-4 text-zinc-600" aria-hidden="true" />
+          <ListTodo className="size-4 text-zinc-600" aria-hidden="true" />
           <span className="text-sm font-medium text-zinc-700">ステータス</span>
           <ToggleGroup
             type="single"
@@ -235,7 +235,7 @@ export function TaskFilterBar({ filters, filterOptions, onChange }: TaskFilterBa
         <div className="flex flex-wrap items-center gap-3">
           <SelectFilter
             value={filters.itemId}
-            icon={<Package className="h-4 w-4 text-zinc-500" />}
+            icon={<Package className="size-4 text-zinc-500" />}
             placeholder="物品選択"
             options={filterOptions.items}
             className="w-[180px]"
@@ -243,7 +243,7 @@ export function TaskFilterBar({ filters, filterOptions, onChange }: TaskFilterBa
           />
           <SelectFilter
             value={filters.leaderUserId}
-            icon={<User className="h-4 w-4 text-zinc-500" />}
+            icon={<User className="size-4 text-zinc-500" />}
             placeholder="指揮者"
             options={filterOptions.leaders}
             className="w-[160px]"
@@ -251,7 +251,7 @@ export function TaskFilterBar({ filters, filterOptions, onChange }: TaskFilterBa
           />
           <SelectFilter
             value={filters.fromLocationId}
-            icon={<MapPin className="h-4 w-4 text-zinc-500" />}
+            icon={<MapPin className="size-4 text-zinc-500" />}
             placeholder="From"
             options={filterOptions.locations}
             className="w-[180px]"
@@ -260,7 +260,7 @@ export function TaskFilterBar({ filters, filterOptions, onChange }: TaskFilterBa
           />
           <SelectFilter
             value={filters.toLocationId}
-            icon={<MapPin className="h-4 w-4 text-zinc-500" />}
+            icon={<MapPin className="size-4 text-zinc-500" />}
             placeholder="To"
             options={filterOptions.locations}
             className="w-[180px]"
@@ -272,7 +272,7 @@ export function TaskFilterBar({ filters, filterOptions, onChange }: TaskFilterBa
 
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex flex-wrap items-center gap-2">
-          <Filter className="h-4 w-4 text-zinc-600" aria-hidden="true" />
+          <Filter className="size-4 text-zinc-600" aria-hidden="true" />
           {tags.map((tag) => (
             <Badge
               key={tag.key}
@@ -294,7 +294,7 @@ export function TaskFilterBar({ filters, filterOptions, onChange }: TaskFilterBa
                 className="ml-1 rounded-full p-0.5 hover:bg-zinc-100"
                 aria-label={`${tag.label}フィルターを削除`}
               >
-                <X className="h-3 w-3" aria-hidden="true" />
+                <X className="size-3" aria-hidden="true" />
               </button>
             </Badge>
           ))}

--- a/src/features/admin/tasks/ui/task-form-dialog.tsx
+++ b/src/features/admin/tasks/ui/task-form-dialog.tsx
@@ -47,7 +47,7 @@ function FieldError({ message }: { message?: string }) {
 
   return (
     <p className="mt-1 flex items-center gap-1 text-xs text-red-600">
-      <AlertCircle className="h-3.5 w-3.5" />
+      <AlertCircle className="size-3.5" />
       {message}
     </p>
   );
@@ -211,7 +211,7 @@ function TaskLocationSection({
   return (
     <section>
       <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold">
-        <MapPin className="h-4 w-4" />
+        <MapPin className="size-4" />
         場所
       </h3>
       <div className="grid grid-cols-[1fr_auto_1fr] items-start gap-3">
@@ -255,7 +255,7 @@ function TaskLocationSection({
         </div>
 
         <div className="pt-8 text-zinc-400">
-          <Triangle className="h-4 w-4 rotate-90 fill-current" />
+          <Triangle className="size-4 rotate-90 fill-current" />
         </div>
 
         <div className="space-y-1.5">
@@ -316,7 +316,7 @@ function TaskItemSection({
   return (
     <section>
       <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold">
-        <Package className="h-4 w-4" />
+        <Package className="size-4" />
         物品
       </h3>
       <div className="space-y-1.5">
@@ -377,7 +377,7 @@ function TaskScheduleSection({
   return (
     <section>
       <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold">
-        <Clock3 className="h-4 w-4" />
+        <Clock3 className="size-4" />
         予定時刻
       </h3>
       <div className="grid grid-cols-[1fr_auto_1fr] items-start gap-3">
@@ -406,7 +406,7 @@ function TaskScheduleSection({
         </div>
 
         <div className="pt-8 text-zinc-400">
-          <Triangle className="h-4 w-4 rotate-90 fill-current" />
+          <Triangle className="size-4 rotate-90 fill-current" />
         </div>
 
         <div className="space-y-1.5">
@@ -441,7 +441,7 @@ function TaskNoteSection({ form }: { form: TaskForm }) {
   return (
     <section>
       <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold">
-        <NotebookPen className="h-4 w-4" />
+        <NotebookPen className="size-4" />
         タスク備考
       </h3>
       <Textarea
@@ -537,7 +537,7 @@ export function TaskFormDialog({
 
           {submitError ? (
             <p className="flex items-center gap-1 text-sm text-red-600">
-              <AlertCircle className="h-4 w-4" />
+              <AlertCircle className="size-4" />
               {submitError}
             </p>
           ) : null}

--- a/src/features/admin/tasks/ui/task-list-page-view.tsx
+++ b/src/features/admin/tasks/ui/task-list-page-view.tsx
@@ -71,7 +71,7 @@ export function TaskListPageView({ tasks, filterOptions }: TaskListPageViewProps
             disabled={isPending}
             onClick={() => setCreateOpen(true)}
           >
-            <CirclePlus className="h-4 w-4" />
+            <CirclePlus className="size-4" />
             タスクを追加
           </Button>
         </div>

--- a/src/features/admin/tasks/ui/task-table.tsx
+++ b/src/features/admin/tasks/ui/task-table.tsx
@@ -30,10 +30,10 @@ type TaskTableProps = {
 
 function sortIconClass(sort: TaskSortState, key: TaskSortKey): string {
   if (sort.key !== key) {
-    return "h-3.5 w-3.5 opacity-70";
+    return "size-3.5 opacity-70";
   }
 
-  return sort.direction === "asc" ? "h-3.5 w-3.5" : "h-3.5 w-3.5 rotate-180";
+  return sort.direction === "asc" ? "size-3.5" : "size-3.5 rotate-180";
 }
 
 function TruncatedCellText({
@@ -169,7 +169,7 @@ export function TaskTable({ tasks, sort, isNavigating, onSort, onEdit, onDelete 
                   onClick={() => onEdit(task)}
                   aria-label="編集"
                 >
-                  <Pencil className="h-4 w-4 text-green-600" aria-hidden="true" />
+                  <Pencil className="size-4 text-green-600" aria-hidden="true" />
                 </Button>
               </TableCell>
               <TableCell className="text-center bg-white sticky right-0 z-10">
@@ -180,7 +180,7 @@ export function TaskTable({ tasks, sort, isNavigating, onSort, onEdit, onDelete 
                   onClick={() => onDelete(task)}
                   aria-label="削除"
                 >
-                  <Trash2 className="h-4 w-4 text-red-600" aria-hidden="true" />
+                  <Trash2 className="size-4 text-red-600" aria-hidden="true" />
                 </Button>
               </TableCell>
             </TableRow>

--- a/src/features/auth/ui/login-form.tsx
+++ b/src/features/auth/ui/login-form.tsx
@@ -20,7 +20,7 @@ function FieldError({ messages }: { messages?: string[] }) {
     <>
       {messages.map((msg) => (
         <div key={msg} className="flex items-start gap-1 text-[#C91111]">
-          <CircleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <CircleAlert className="mt-0.5 size-3.5 shrink-0" />
           <p className="text-xs leading-5">{msg}</p>
         </div>
       ))}
@@ -84,7 +84,7 @@ export function LoginForm() {
                 aria-label={showPassword ? "パスワードを隠す" : "パスワードを表示"}
                 className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 hover:bg-muted"
               >
-                {showPassword ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+                {showPassword ? <Eye className="size-4" /> : <EyeOff className="size-4" />}
               </button>
             </div>
             <FieldError messages={state.fieldErrors?.password} />

--- a/src/features/auth/ui/sign-up-form.tsx
+++ b/src/features/auth/ui/sign-up-form.tsx
@@ -20,7 +20,7 @@ function FieldError({ messages }: { messages?: string[] }) {
     <>
       {messages.map((msg) => (
         <div key={msg} className="flex items-start gap-1 text-[#C91111]">
-          <CircleAlert className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          <CircleAlert className="mt-0.5 size-3.5 shrink-0" />
           <p className="text-xs leading-5">{msg}</p>
         </div>
       ))}
@@ -104,7 +104,7 @@ export function SignUpForm() {
                 aria-label={showPassword ? "パスワードを隠す" : "パスワードを表示"}
                 className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-1 hover:bg-muted"
               >
-                {showPassword ? <Eye className="h-4 w-4" /> : <EyeOff className="h-4 w-4" />}
+                {showPassword ? <Eye className="size-4" /> : <EyeOff className="size-4" />}
               </button>
             </div>
             <FieldError messages={state.fieldErrors?.password} />

--- a/src/features/user/tasks/ui/task-detail-dialog.tsx
+++ b/src/features/user/tasks/ui/task-detail-dialog.tsx
@@ -167,7 +167,7 @@ export function TaskDetailDialog({
                       <span className="flex items-center gap-1.5">
                         <span
                           className={cn(
-                            "inline-block h-2.5 w-2.5 rounded-full",
+                            "inline-block size-2.5 rounded-full",
                             getStatusDotClass(status),
                           )}
                         />
@@ -228,7 +228,7 @@ export function TaskDetailDialog({
               aria-live="assertive"
               className="flex items-center gap-1 text-xs text-red-600"
             >
-              <AlertCircle className="h-3.5 w-3.5" aria-hidden="true" />
+              <AlertCircle className="size-3.5" aria-hidden="true" />
               {errorMessage}
             </p>
           ) : null}

--- a/src/features/user/tasks/ui/task-list-page-view.tsx
+++ b/src/features/user/tasks/ui/task-list-page-view.tsx
@@ -140,7 +140,7 @@ export function TaskListPageView({ currentUser, tasks, filterOptions }: TaskList
         </div>
 
         {tasks.length > 0 ? (
-          <ul role="list" className="space-y-2">
+          <ul className="space-y-2">
             {tasks.map((task) => (
               <li key={task.taskId}>
                 <TaskCard task={task} onClick={() => setSelectedTaskId(task.taskId)} />
@@ -150,13 +150,12 @@ export function TaskListPageView({ currentUser, tasks, filterOptions }: TaskList
         ) : null}
 
         {!isPending && tasks.length === 0 ? (
-          <div
-            className="rounded-lg border border-[#e5e5e5] bg-white px-4 py-8 shadow-sm"
-            role="status"
+          <output
+            className="block rounded-lg border border-[#e5e5e5] bg-white px-4 py-8 text-center text-sm text-[#737373] shadow-sm"
             aria-live="polite"
           >
-            <p className="text-center text-sm text-[#737373]">該当するタスクはありません</p>
-          </div>
+            該当するタスクはありません
+          </output>
         ) : null}
       </section>
 

--- a/src/lib/auth/guards.ts
+++ b/src/lib/auth/guards.ts
@@ -47,6 +47,7 @@ export async function requireAuthenticatedUser(): Promise<CurrentUserProfile> {
   return currentUser;
 }
 
+// react-doctor-disable-next-line deslop/unused-export
 export async function requireUserWithRoles<const TRoles extends readonly AppRole[]>(
   roles: TRoles,
 ): Promise<CurrentUserProfile & { role: TRoles[number] }> {

--- a/src/lib/auth/roles.ts
+++ b/src/lib/auth/roles.ts
@@ -6,6 +6,7 @@ export const APP_ROLES = {
   USER: 2,
 } as const;
 
+// react-doctor-disable-next-line deslop/unused-export
 export const APP_ROLE_VALUES = [APP_ROLES.ADMIN, APP_ROLES.LEADER, APP_ROLES.USER] as const;
 
 export type AppRole = Tables<"users">["role"] & (typeof APP_ROLE_VALUES)[number];

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,6 +1,8 @@
 import { createBrowserClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/schema.gen";
 
-export function createClient() {
+export function createClient(): SupabaseClient<Database> {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const supabaseKey = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY;
 
@@ -8,5 +10,5 @@ export function createClient() {
     throw new Error("Missing Supabase environment variables");
   }
 
-  return createBrowserClient(supabaseUrl, supabaseKey);
+  return createBrowserClient<Database>(supabaseUrl, supabaseKey);
 }

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,7 +1,9 @@
 import { createServerClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
 import { cookies } from "next/headers";
+import type { Database } from "@/types/schema.gen";
 
-export async function createClient() {
+export async function createClient(): Promise<SupabaseClient<Database>> {
   const cookieStore = await cookies();
 
   const supabaseUrl = process.env.SUPABASE_INTERNAL_URL || process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -13,7 +15,7 @@ export async function createClient() {
     );
   }
 
-  return createServerClient(supabaseUrl, supabaseKey, {
+  return createServerClient<Database>(supabaseUrl, supabaseKey, {
     cookies: {
       getAll() {
         return cookieStore.getAll();


### PR DESCRIPTION
## 概要

Figma の場所一覧デザインに合わせて、管理者画面の場所一覧 UI を調整しました。
左上のロゴ追加は今回の対象外として変更していません。

## 変更点

- 場所一覧ページの背景、余白、コンテンツ幅を Figma に合わせて調整
- 場所ツリーの行表示を白背景・角丸・階層インデント付きの見た目に変更
- 展開アイコンを `ChevronRight` / `ChevronDown` の切り替えに変更
- ツリー内の追加・編集・削除ボタンのサイズと余白を調整
- 「エリアを追加」ボタンは他の管理画面の追加ボタンと同じ見た目に統一
- React Doctor 指摘に合わせて、追加ボタンのアイコンサイズ指定を `size-4` に整理


### 対象コミット

- `7fe2df9` `[fix] React Doctor指摘のサイズ指定を整理`
- `76376db` `[fix] タスク一覧の冗長なARIA指定を整理`
- `ed549e6` `[chore] 未使用依存関係の指摘を整理`
- `ff4924c` `[chore] pnpmの依存取得ポリシーを設定`
- `4ddf69d` `[fix] 認証ロールの公開API意図を明示`

### Reactdoctor指摘部分での変更内容

- `w-N h-N` のような同一サイズ指定を `size-N` に置き換え
- `<ul role="list">` の冗長な role を削除
- `role="status"` を semantic な `<output>` に変更
- 未使用の direct dependency を削除
  - `@radix-ui/react-visually-hidden`
  - `date-fns`
- `supabase` CLI は `package.json` の script に追加し、devDependency として使う意図を明示
- `@supabase/supabase-js` は Supabase client の戻り値型として明示
- `pnpm-workspace.yaml` に依存取得ポリシーを追加
  - `minimumReleaseAge: 10080`
  - `trustPolicy: no-downgrade`
- `requireUserWithRoles` と `APP_ROLE_VALUES` は将来利用を見込む公開 API として export を残し、React Doctor の未使用 export 指摘だけ明示的に抑制




## スクリーンショット

確認対象画面: `/admin/locations`

<img width="1052" height="961" alt="image" src="https://github.com/user-attachments/assets/be37e15c-285a-4ed9-8036-0d5071ff05e8" />

## 動作確認手順


1. 管理者ユーザーでログインする
2. `/admin/locations` を開く
3. 場所ツリーの表示、展開/折りたたみ、追加・編集・削除ボタンの見た目を確認する

実行済みチェック:

- `pnpm typecheck`
- `pnpm lint`

## レビューしてほしいポイント

-[ Figma の場所一覧デザイン](https://www.figma.com/design/iTdRZ2VaXVXK7JlAj6BXBY/%E7%89%A9%E5%93%81Go-%E3%83%87%E3%82%B6%E3%82%A4%E3%83%B3?node-id=1265-71226&t=HCrdms2IFEZrrGIQ-1)と比べて、余白・階層インデント・行の見た目に違和感がないか
- 「エリアを追加」ボタンは崩れていないか
- 場所ツリーの縦線や展開アイコンの見え方が自然か
- 既存の場所追加・編集・削除操作に影響がなさそうか
