### PR TITLE
[fix] CarouselのreInitリスナーを解除する

### DIFF
--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -98,6 +98,7 @@ function Carousel({
     api.on("select", onSelect);
 
     return () => {
+      api?.off("reInit", onSelect);
       api?.off("select", onSelect);
     };
   }, [api, onSelect]);


### PR DESCRIPTION
## 概要

Carousel コンポーネントで Embla の `reInit` event listener が cleanup されていなかったため、unmount / remount 時に古い listener が残る可能性を修正しました。

## 変更点

- `api.on("reInit", onSelect)` に対応する `api.off("reInit", onSelect)` を cleanup に追加
- `reInit` / `select` の event listener 登録と解除が対称になるよう修正

## 関連Issue

- #48

## スクリーンショット（UI変更がある場合）

UI変更なし

## 動作確認手順

1. `pnpm typecheck` を実行する
2. `pnpm lint` を実行する

## レビューしてほしいポイント

- `reInit` listener の cleanup が Embla の lifecycle に対して適切か
- 既存の `select` listener cleanup と同じ文脈で問題ないか

## セルフチェックリスト

- [ ] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない
- [ ] テストコードを追加・修正した（必要な場合）