### PR TITLE
[UI/Fix] アカウント詳細ポップの上部余白を調整

### DIFF
--- a/src/components/layout/admin-header.tsx
+++ b/src/components/layout/admin-header.tsx
@@ -128,21 +128,19 @@ export function AdminHeader({ currentUserName, currentUserRole }: AdminHeaderPro
               sideOffset={12}
               className="w-[min(92vw,243px)] rounded-[10px] border border-[#e5e5e5] p-5 text-[#0a0a0a] shadow-[0px_10px_15px_-3px_rgba(0,0,0,0.1),0px_4px_6px_-4px_rgba(0,0,0,0.1)] motion-reduce:animate-none"
             >
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => setOpen(false)}
+                className="absolute top-3 right-4 size-9 rounded-full text-[#171717] hover:bg-[#f5f5f5] focus-visible:ring-3 focus-visible:ring-[#121212]/20 focus-visible:ring-offset-2 focus-visible:outline-hidden motion-reduce:transition-none"
+                aria-label="プロフィールを閉じる"
+              >
+                <X className="size-5" aria-hidden="true" />
+              </Button>
               <div className="space-y-3.25">
                 <div className="space-y-2">
-                  <div className="flex justify-end">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => setOpen(false)}
-                      className="size-8 rounded-full text-[#171717] hover:bg-[#f5f5f5] focus-visible:ring-3 focus-visible:ring-[#121212]/20 focus-visible:ring-offset-2 focus-visible:outline-hidden motion-reduce:transition-none"
-                      aria-label="プロフィールを閉じる"
-                    >
-                      <X className="size-4" aria-hidden="true" />
-                    </Button>
-                  </div>
-                  <div className="px-2">
+                  <div className="px-2 pr-10">
                     <p className="flex items-baseline gap-1 text-[20px] leading-5 font-medium text-[#0a0a0a]">
                       <span className="text-xl">{currentUserName}</span>
                       <span className="text-xs leading-none">さん</span>

--- a/src/components/layout/admin-header.tsx
+++ b/src/components/layout/admin-header.tsx
@@ -138,12 +138,12 @@ export function AdminHeader({ currentUserName, currentUserRole }: AdminHeaderPro
               >
                 <X className="size-5" aria-hidden="true" />
               </Button>
-              <div className="space-y-3.25">
+              <div className="space-y-3.25 pt-6">
                 <div className="space-y-2">
                   <div className="px-2 pr-10">
-                    <p className="flex items-baseline gap-1 text-[20px] leading-5 font-medium text-[#0a0a0a]">
-                      <span className="text-xl">{currentUserName}</span>
-                      <span className="text-xs leading-none">さん</span>
+                    <p className="flex min-w-0 items-baseline gap-1 text-[20px] leading-5 font-medium text-[#0a0a0a]">
+                      <span className="min-w-0 truncate text-xl">{currentUserName}</span>
+                      <span className="shrink-0 text-xs leading-none">さん</span>
                     </p>
                   </div>
                   <div className="rounded-lg px-2 py-1">

--- a/src/features/user/tasks/ui/user-task-header.tsx
+++ b/src/features/user/tasks/ui/user-task-header.tsx
@@ -105,21 +105,19 @@ export function UserTaskHeader({
               sideOffset={12}
               className="w-[min(92vw,243px)] rounded-[10px] p-5"
             >
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={() => setOpen(false)}
+                className="absolute top-3 right-4 size-9 rounded-full hover:bg-[#f5f5f5]"
+                aria-label="プロフィールを閉じる"
+              >
+                <X className="size-5" />
+              </Button>
               <div className="space-y-3.25">
                 <div className="space-y-2">
-                  <div className="flex justify-end">
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => setOpen(false)}
-                      className="size-8 rounded-full hover:bg-[#f5f5f5]"
-                      aria-label="プロフィールを閉じる"
-                    >
-                      <X className="size-4" />
-                    </Button>
-                  </div>
-                  <div className="px-2">
+                  <div className="px-2 pr-10">
                     <p className="flex items-baseline gap-1 text-xl leading-5 font-medium">
                       <span>{currentUserName}</span>
                       <span className="text-xs leading-none">さん</span>

--- a/src/features/user/tasks/ui/user-task-header.tsx
+++ b/src/features/user/tasks/ui/user-task-header.tsx
@@ -115,12 +115,12 @@ export function UserTaskHeader({
               >
                 <X className="size-5" />
               </Button>
-              <div className="space-y-3.25">
+              <div className="space-y-3.25 pt-6">
                 <div className="space-y-2">
                   <div className="px-2 pr-10">
-                    <p className="flex items-baseline gap-1 text-xl leading-5 font-medium">
-                      <span>{currentUserName}</span>
-                      <span className="text-xs leading-none">さん</span>
+                    <p className="flex min-w-0 items-baseline gap-1 text-xl leading-5 font-medium">
+                      <span className="min-w-0 truncate">{currentUserName}</span>
+                      <span className="shrink-0 text-xs leading-none">さん</span>
                     </p>
                   </div>
                   <div className="rounded-lg px-2 py-1">

--- a/src/features/user/tasks/ui/user-task-header.tsx
+++ b/src/features/user/tasks/ui/user-task-header.tsx
@@ -74,7 +74,6 @@ export function UserTaskHeader({
   onDayChange,
 }: UserTaskHeaderProps) {
   const [open, setOpen] = useState(false);
-  const disableUserSwitch = currentRole === APP_ROLES.USER;
   const disableAdminSwitch = currentRole !== APP_ROLES.ADMIN;
 
   return (
@@ -138,7 +137,7 @@ export function UserTaskHeader({
                   <SwitchRow
                     href="/tasks"
                     label="ユーザー画面に切り替え"
-                    disabled={disableUserSwitch}
+                    disabled
                     onNavigate={() => setOpen(false)}
                   />
                   <SwitchRow


### PR DESCRIPTION
## 概要

アカウント詳細ポップの上部余白と閉じるボタンの配置を調整しました。

## 変更点

- Admin/User両方のアカウント詳細ポップで、閉じるボタンを右上に配置し、本文を押し下げないようにしました。
- ユーザー名が長い場合に閉じるボタンと被りにくいよう、名前表示を省略表示できる形にしました。

ついでに
- User画面のアカウント詳細ポップで、「ユーザー画面に切り替え」を現在画面として disabled 表示にしました。

## 関連Issue

- #71

## スクリーンショット（UI変更がある場合）
### Before

| Admin | User |
| ----- | ---- |
|<img width="321" height="462" alt="Image" src="https://github.com/user-attachments/assets/6af161ba-b9dd-4fa8-bb98-4f45fd072cf0" />|<img width="418" height="280" alt="Image" src="https://github.com/user-attachments/assets/b9fd631b-255f-4e13-90d5-8a686869d485" />|

### After
| Admin | User |
| ----- | ---- |
| <img src="https://gist.githubusercontent.com/screana/5fb3f5d207bd4db5747c1b2b748be237/raw/30f6f174c2b51fa895b3cb338341a3f17827e65c/admin-account-popover-after.svg" width="320"> | <img src="https://gist.githubusercontent.com/screana/5fb3f5d207bd4db5747c1b2b748be237/raw/c7e7cee160242ca37dcad6580bde44667fdf27a4/user-account-popover-after.svg" width="320"> |

## 動作確認手順

1. `mise exec -- pnpm typecheck`
2. `mise exec -- pnpm lint`
3. Admin/Userそれぞれの画面右上にあるプロフィールボタンを押し、アカウント詳細ポップを確認する
4. User画面で「ユーザー画面に切り替え」が disabled 表示になっていることを確認する

## レビューしてほしいポイント

- Figmaのアカウント詳細ポップに対して、上部余白と閉じるボタンの位置が自然か
- 長いユーザー名でも閉じるボタンと表示が干渉しにくいか
- User画面の現在画面リンクを disabled 表示にする挙動が自然か

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない
- [ ] テストコードを追加・修正した（必要な場合）
