### PR TITLE
[UI] Adminの追加ボタンをFigmaのデザインに合わせる

### DIFF
--- a/src/features/admin/items/ui/item-list-page-view.tsx
+++ b/src/features/admin/items/ui/item-list-page-view.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { CirclePlus } from "lucide-react";
 import { useState } from "react";
-import { Button } from "@/components/ui/button";
+import { AdminAddButton } from "../../ui/admin-add-button";
 import type { AdminItem } from "../model/types";
 import { ItemDeleteDialog } from "./item-delete-dialog";
 import { ItemFormDialog } from "./item-form-dialog";
@@ -25,14 +24,12 @@ export function ItemListPageView({ items }: ItemListPageViewProps) {
             <h1 className="text-2xl font-semibold text-zinc-900">物品一覧</h1>
             <p className="mt-1 text-sm text-zinc-500">タスクで使用する物品を管理します。</p>
           </div>
-          <Button
+          <AdminAddButton
             type="button"
-            className="h-[52px] rounded-md bg-[#171717] px-3 py-4 text-sm font-normal text-[#fafafa] shadow-[0_1px_1px_rgba(0,0,0,0.1)] hover:bg-[#171717]/90"
             onClick={() => setCreateOpen(true)}
           >
-            <CirclePlus className="size-5" />
             物品を追加
-          </Button>
+          </AdminAddButton>
         </div>
 
         <ItemTable

--- a/src/features/admin/items/ui/item-list-page-view.tsx
+++ b/src/features/admin/items/ui/item-list-page-view.tsx
@@ -27,10 +27,10 @@ export function ItemListPageView({ items }: ItemListPageViewProps) {
           </div>
           <Button
             type="button"
-            className="bg-zinc-950 text-white hover:bg-zinc-800"
+            className="h-[52px] rounded-md bg-[#171717] px-3 py-4 text-sm font-normal text-[#fafafa] shadow-[0_1px_1px_rgba(0,0,0,0.1)] hover:bg-[#171717]/90"
             onClick={() => setCreateOpen(true)}
           >
-            <CirclePlus className="size-4" />
+            <CirclePlus className="size-5" />
             物品を追加
           </Button>
         </div>

--- a/src/features/admin/items/ui/item-list-page-view.tsx
+++ b/src/features/admin/items/ui/item-list-page-view.tsx
@@ -24,10 +24,7 @@ export function ItemListPageView({ items }: ItemListPageViewProps) {
             <h1 className="text-2xl font-semibold text-zinc-900">物品一覧</h1>
             <p className="mt-1 text-sm text-zinc-500">タスクで使用する物品を管理します。</p>
           </div>
-          <AdminAddButton
-            type="button"
-            onClick={() => setCreateOpen(true)}
-          >
+          <AdminAddButton type="button" onClick={() => setCreateOpen(true)}>
             物品を追加
           </AdminAddButton>
         </div>

--- a/src/features/admin/locations/ui/location-list-page-view.tsx
+++ b/src/features/admin/locations/ui/location-list-page-view.tsx
@@ -74,10 +74,10 @@ export function LocationListPageView({ locations }: LocationListPageViewProps) {
         <div className="flex justify-end">
           <Button
             type="button"
-            className="bg-zinc-950 text-white hover:bg-zinc-800"
+            className="h-[52px] rounded-md bg-[#171717] px-3 py-4 text-sm font-normal text-[#fafafa] shadow-[0_1px_1px_rgba(0,0,0,0.1)] hover:bg-[#171717]/90"
             onClick={() => dispatchDialog({ type: "open-create-root" })}
           >
-            <CirclePlus className="size-4" />
+            <CirclePlus className="size-5" />
             エリアを追加
           </Button>
         </div>

--- a/src/features/admin/locations/ui/location-list-page-view.tsx
+++ b/src/features/admin/locations/ui/location-list-page-view.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { CirclePlus, FoldVertical, UnfoldVertical } from "lucide-react";
+import { FoldVertical, UnfoldVertical } from "lucide-react";
 import { useMemo, useReducer, useState } from "react";
 import { Button } from "@/components/ui/button";
+import { AdminAddButton } from "../../ui/admin-add-button";
 import type { AdminLocation } from "../model/types";
 import { LocationDeleteDialog } from "./location-delete-dialog";
 import { LocationFormDialog } from "./location-form-dialog";
@@ -72,14 +73,12 @@ export function LocationListPageView({ locations }: LocationListPageViewProps) {
         <h1 className="sr-only">場所一覧</h1>
 
         <div className="flex justify-end">
-          <Button
+          <AdminAddButton
             type="button"
-            className="h-[52px] rounded-md bg-[#171717] px-3 py-4 text-sm font-normal text-[#fafafa] shadow-[0_1px_1px_rgba(0,0,0,0.1)] hover:bg-[#171717]/90"
             onClick={() => dispatchDialog({ type: "open-create-root" })}
           >
-            <CirclePlus className="size-5" />
             エリアを追加
-          </Button>
+          </AdminAddButton>
         </div>
 
         <div className="flex justify-end gap-2">

--- a/src/features/admin/tasks/ui/task-list-page-view.tsx
+++ b/src/features/admin/tasks/ui/task-list-page-view.tsx
@@ -64,11 +64,7 @@ export function TaskListPageView({ tasks, filterOptions }: TaskListPageViewProps
     <main className="px-16 py-8">
       <div className="space-y-4">
         <div className="flex justify-end">
-          <AdminAddButton
-            type="button"
-            disabled={isPending}
-            onClick={() => setCreateOpen(true)}
-          >
+          <AdminAddButton type="button" disabled={isPending} onClick={() => setCreateOpen(true)}>
             タスクを追加
           </AdminAddButton>
         </div>

--- a/src/features/admin/tasks/ui/task-list-page-view.tsx
+++ b/src/features/admin/tasks/ui/task-list-page-view.tsx
@@ -67,11 +67,11 @@ export function TaskListPageView({ tasks, filterOptions }: TaskListPageViewProps
         <div className="flex justify-end">
           <Button
             type="button"
-            className="bg-zinc-950 text-white hover:bg-zinc-800"
+            className="h-[52px] rounded-md bg-[#171717] px-3 py-4 text-sm font-normal text-[#fafafa] shadow-[0_1px_1px_rgba(0,0,0,0.1)] hover:bg-[#171717]/90"
             disabled={isPending}
             onClick={() => setCreateOpen(true)}
           >
-            <CirclePlus className="size-4" />
+            <CirclePlus className="size-5" />
             タスクを追加
           </Button>
         </div>

--- a/src/features/admin/tasks/ui/task-list-page-view.tsx
+++ b/src/features/admin/tasks/ui/task-list-page-view.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { CirclePlus } from "lucide-react";
 import { useQueryStates } from "nuqs";
 import { useState, useTransition } from "react";
-import { Button } from "@/components/ui/button";
+import { AdminAddButton } from "../../ui/admin-add-button";
 import { taskListQueryStatesParsers } from "../model/query-state";
 import type {
   AdminTask,
@@ -65,15 +64,13 @@ export function TaskListPageView({ tasks, filterOptions }: TaskListPageViewProps
     <main className="px-16 py-8">
       <div className="space-y-4">
         <div className="flex justify-end">
-          <Button
+          <AdminAddButton
             type="button"
-            className="h-[52px] rounded-md bg-[#171717] px-3 py-4 text-sm font-normal text-[#fafafa] shadow-[0_1px_1px_rgba(0,0,0,0.1)] hover:bg-[#171717]/90"
             disabled={isPending}
             onClick={() => setCreateOpen(true)}
           >
-            <CirclePlus className="size-5" />
             タスクを追加
-          </Button>
+          </AdminAddButton>
         </div>
 
         <TaskFilterBar

--- a/src/features/admin/ui/admin-add-button.tsx
+++ b/src/features/admin/ui/admin-add-button.tsx
@@ -1,0 +1,18 @@
+import { CirclePlus } from "lucide-react";
+import type { ComponentProps } from "react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+type AdminAddButtonProps = ComponentProps<typeof Button>;
+
+const adminAddButtonClass =
+  "h-[52px] rounded-md bg-[#171717] px-3 py-4 text-sm font-normal text-[#fafafa] shadow-[0_1px_1px_rgba(0,0,0,0.1)] hover:bg-[#171717]/90";
+
+export function AdminAddButton({ className, children, ...props }: AdminAddButtonProps) {
+  return (
+    <Button className={cn(adminAddButtonClass, className)} {...props}>
+      <CirclePlus className="size-5" />
+      {children}
+    </Button>
+  );
+}


### PR DESCRIPTION
## 概要

Admin画面の追加ボタンをFigmaのデザインに合わせました。

## 変更点

- タスク一覧の「タスクを追加」ボタンの見た目を調整しました。
- 物品一覧の「物品を追加」ボタンの見た目を調整しました。
- 場所一覧の「エリアを追加」ボタンの見た目を調整しました。
- Admin画面の追加ボタンを共通コンポーネント化しました。

## 関連Issue

- #68

## スクリーンショット（UI変更がある場合）

| Figma| 実環境 |
| ------ | ----- |
| <img width="1162" height="802" alt="image" src="https://github.com/user-attachments/assets/65e0f0da-7979-4a78-9ec2-f58d2c82c1be" />| <img width="2222" height="1015" alt="image" src="https://github.com/user-attachments/assets/72a679cd-ce0a-41a7-8afe-c7a85b2a2fd2" /> |
|<img width="360" height="250" alt="image" src="https://github.com/user-attachments/assets/8795b149-6226-4250-9b40-da867b234ef2" /> | <img width="1453" height="668" alt="image" src="https://github.com/user-attachments/assets/d3e1305a-75a8-4d4f-8087-6c4df12e4a6f" />|
|<img width="447" height="379" alt="image" src="https://github.com/user-attachments/assets/6249aabf-ed73-4025-b9a9-6e3e77357812" />| <img width="1409" height="875" alt="image" src="https://github.com/user-attachments/assets/ef7c5a58-7577-43d7-a6a2-5db3b3c15609" />|

## 動作確認手順

1. Docker を起動した状態で `mise run dev` を実行する
2. `http://127.0.0.1:3000/login` にアクセスする
3. 管理者アカウントでログインする
4. `http://127.0.0.1:3000/admin/tasks` にアクセスし、「タスクを追加」ボタンの見た目を確認する
5. `http://127.0.0.1:3000/admin/items` にアクセスし、「物品を追加」ボタンの見た目を確認する
6. `http://127.0.0.1:3000/admin/locations` にアクセスし、「エリアを追加」ボタンの見た目を確認する
7. `mise exec -- pnpm fmt:check .` を実行する
8. `mise exec -- pnpm typecheck` を実行する
9. `mise exec -- pnpm lint` を実行する
10. 終了時は `mise run down` を実行する

## レビューしてほしいポイント

- 追加ボタンの高さ、角丸、アイコンサイズ、文字サイズがFigmaの意図に合っているか
- Admin画面の追加ボタンとして共通コンポーネント化する粒度で問題ないか
- 既存の追加導線に影響が出ていないか

## セルフチェックリスト

- [x] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない
- [ ] テストコードを追加・修正した（必要な場合）