### PR TITLE
[UI] ステータスバッジの幅を3文字基準で揃える

### DIFF
--- a/src/features/admin/tasks/ui/task-table.tsx
+++ b/src/features/admin/tasks/ui/task-table.tsx
@@ -11,6 +11,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { TaskStatusBadge } from "@/features/tasks/ui/task-status-badge";
 import {
   getEventDayBadgeClass,
   getEventDayLabel,
@@ -135,9 +136,9 @@ export function TaskTable({ tasks, sort, isNavigating, onSort, onEdit, onDelete 
                 </Badge>
               </TableCell>
               <TableCell className="text-center">
-                <Badge className={getStatusBadgeClass(task.currentStatus)}>
+                <TaskStatusBadge className={getStatusBadgeClass(task.currentStatus)}>
                   {getStatusLabel(task.currentStatus)}
-                </Badge>
+                </TaskStatusBadge>
               </TableCell>
               <TableCell className="text-center">
                 <TruncatedCellText value={task.fromLocationName} />

--- a/src/features/admin/tasks/ui/task-table.tsx
+++ b/src/features/admin/tasks/ui/task-table.tsx
@@ -12,12 +12,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { TaskStatusBadge } from "@/features/tasks/ui/task-status-badge";
-import {
-  getEventDayBadgeClass,
-  getEventDayLabel,
-  getStatusBadgeClass,
-  getStatusLabel,
-} from "../model/mappers";
+import { getEventDayBadgeClass, getEventDayLabel } from "../model/mappers";
 import type { AdminTask, TaskSortKey, TaskSortState } from "../model/types";
 
 type TaskTableProps = {
@@ -136,9 +131,7 @@ export function TaskTable({ tasks, sort, isNavigating, onSort, onEdit, onDelete 
                 </Badge>
               </TableCell>
               <TableCell className="text-center">
-                <TaskStatusBadge className={getStatusBadgeClass(task.currentStatus)}>
-                  {getStatusLabel(task.currentStatus)}
-                </TaskStatusBadge>
+                <TaskStatusBadge status={task.currentStatus} colorScheme="admin" />
               </TableCell>
               <TableCell className="text-center">
                 <TruncatedCellText value={task.fromLocationName} />

--- a/src/features/tasks/model/task-status.ts
+++ b/src/features/tasks/model/task-status.ts
@@ -1,0 +1,13 @@
+import type { Tables } from "@/types/schema.gen";
+
+export type TaskStatus = Tables<"tasks">["current_status"] & (0 | 1 | 2);
+
+const taskStatusLabelMap: Record<TaskStatus, string> = {
+  0: "未着手",
+  1: "進行中",
+  2: "完了",
+};
+
+export function getTaskStatusLabel(status: TaskStatus): string {
+  return taskStatusLabelMap[status];
+}

--- a/src/features/tasks/ui/task-status-badge.tsx
+++ b/src/features/tasks/ui/task-status-badge.tsx
@@ -1,20 +1,13 @@
 import type { ComponentProps } from "react";
 import { Badge } from "@/components/ui/badge";
-import type { Tables } from "@/types/schema.gen";
 import { cn } from "@/lib/utils";
+import { getTaskStatusLabel, type TaskStatus } from "../model/task-status";
 
-type TaskStatus = Tables<"tasks">["current_status"] & (0 | 1 | 2);
 type TaskStatusBadgeColorScheme = "admin" | "user";
 
 type TaskStatusBadgeProps = Omit<ComponentProps<typeof Badge>, "children"> & {
   status: TaskStatus;
   colorScheme?: TaskStatusBadgeColorScheme;
-};
-
-const taskStatusLabelMap: Record<TaskStatus, string> = {
-  0: "未着手",
-  1: "進行中",
-  2: "完了",
 };
 
 const taskStatusBadgeClassMap: Record<TaskStatusBadgeColorScheme, Record<TaskStatus, string>> = {
@@ -29,10 +22,6 @@ const taskStatusBadgeClassMap: Record<TaskStatusBadgeColorScheme, Record<TaskSta
     2: "bg-[#007B48] text-white",
   },
 };
-
-export function getTaskStatusLabel(status: TaskStatus): string {
-  return taskStatusLabelMap[status];
-}
 
 export function TaskStatusBadge({
   status,

--- a/src/features/tasks/ui/task-status-badge.tsx
+++ b/src/features/tasks/ui/task-status-badge.tsx
@@ -1,0 +1,9 @@
+import type { ComponentProps } from "react";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
+
+type TaskStatusBadgeProps = ComponentProps<typeof Badge>;
+
+export function TaskStatusBadge({ className, ...props }: TaskStatusBadgeProps) {
+  return <Badge className={cn("min-w-16", className)} {...props} />;
+}

--- a/src/features/tasks/ui/task-status-badge.tsx
+++ b/src/features/tasks/ui/task-status-badge.tsx
@@ -1,9 +1,51 @@
 import type { ComponentProps } from "react";
 import { Badge } from "@/components/ui/badge";
+import type { Tables } from "@/types/schema.gen";
 import { cn } from "@/lib/utils";
 
-type TaskStatusBadgeProps = ComponentProps<typeof Badge>;
+type TaskStatus = Tables<"tasks">["current_status"] & (0 | 1 | 2);
+type TaskStatusBadgeColorScheme = "admin" | "user";
 
-export function TaskStatusBadge({ className, ...props }: TaskStatusBadgeProps) {
-  return <Badge className={cn("min-w-16", className)} {...props} />;
+type TaskStatusBadgeProps = Omit<ComponentProps<typeof Badge>, "children"> & {
+  status: TaskStatus;
+  colorScheme?: TaskStatusBadgeColorScheme;
+};
+
+const taskStatusLabelMap: Record<TaskStatus, string> = {
+  0: "未着手",
+  1: "進行中",
+  2: "完了",
+};
+
+const taskStatusBadgeClassMap: Record<TaskStatusBadgeColorScheme, Record<TaskStatus, string>> = {
+  admin: {
+    0: "bg-zinc-700 text-white",
+    1: "bg-blue-700 text-white",
+    2: "bg-green-700 text-white",
+  },
+  user: {
+    0: "bg-[#595959] text-white",
+    1: "bg-[#005BAB] text-white",
+    2: "bg-[#007B48] text-white",
+  },
+};
+
+export function getTaskStatusLabel(status: TaskStatus): string {
+  return taskStatusLabelMap[status];
+}
+
+export function TaskStatusBadge({
+  status,
+  colorScheme = "user",
+  className,
+  ...props
+}: TaskStatusBadgeProps) {
+  return (
+    <Badge
+      className={cn("min-w-16", taskStatusBadgeClassMap[colorScheme][status], className)}
+      {...props}
+    >
+      {getTaskStatusLabel(status)}
+    </Badge>
+  );
 }

--- a/src/features/user/tasks/ui/task-card.tsx
+++ b/src/features/user/tasks/ui/task-card.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Box, ChevronRight, Clock3 } from "lucide-react";
-import { getTaskStatusLabel, TaskStatusBadge } from "@/features/tasks/ui/task-status-badge";
+import { getTaskStatusLabel } from "@/features/tasks/model/task-status";
+import { TaskStatusBadge } from "@/features/tasks/ui/task-status-badge";
 import type { UserTask } from "../model/types";
 
 type TaskCardProps = {

--- a/src/features/user/tasks/ui/task-card.tsx
+++ b/src/features/user/tasks/ui/task-card.tsx
@@ -1,9 +1,7 @@
 "use client";
 
 import { Box, ChevronRight, Clock3 } from "lucide-react";
-import { TaskStatusBadge } from "@/features/tasks/ui/task-status-badge";
-import { cn } from "@/lib/utils";
-import { getStatusBadgeClass } from "../model/mappers";
+import { getTaskStatusLabel, TaskStatusBadge } from "@/features/tasks/ui/task-status-badge";
 import type { UserTask } from "../model/types";
 
 type TaskCardProps = {
@@ -12,8 +10,7 @@ type TaskCardProps = {
 };
 
 export function TaskCard({ task, onClick }: TaskCardProps) {
-  const statusText =
-    task.currentStatus === 0 ? "未着手" : task.currentStatus === 1 ? "進行中" : "完了";
+  const statusText = getTaskStatusLabel(task.currentStatus);
 
   return (
     <button
@@ -24,14 +21,7 @@ export function TaskCard({ task, onClick }: TaskCardProps) {
     >
       <div className="flex items-center justify-between gap-3 sm:gap-6">
         <div className="flex-1">
-          <TaskStatusBadge
-            className={cn(
-              "h-6 rounded-full px-3 text-xs text-white",
-              getStatusBadgeClass(task.currentStatus),
-            )}
-          >
-            {task.currentStatus === 0 ? "未着手" : task.currentStatus === 1 ? "進行中" : "完了"}
-          </TaskStatusBadge>
+          <TaskStatusBadge status={task.currentStatus} className="h-6 rounded-full px-3 text-xs" />
 
           <div className="mt-3 space-y-2">
             <p className="flex items-center gap-1.5 font-bold">

--- a/src/features/user/tasks/ui/task-card.tsx
+++ b/src/features/user/tasks/ui/task-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Box, ChevronRight, Clock3 } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
+import { TaskStatusBadge } from "@/features/tasks/ui/task-status-badge";
 import { cn } from "@/lib/utils";
 import { getStatusBadgeClass } from "../model/mappers";
 import type { UserTask } from "../model/types";
@@ -24,14 +24,14 @@ export function TaskCard({ task, onClick }: TaskCardProps) {
     >
       <div className="flex items-center justify-between gap-3 sm:gap-6">
         <div className="flex-1">
-          <Badge
+          <TaskStatusBadge
             className={cn(
               "h-6 rounded-full px-3 text-xs text-white",
               getStatusBadgeClass(task.currentStatus),
             )}
           >
             {task.currentStatus === 0 ? "未着手" : task.currentStatus === 1 ? "進行中" : "完了"}
-          </Badge>
+          </TaskStatusBadge>
 
           <div className="mt-3 space-y-2">
             <p className="flex items-center gap-1.5 font-bold">


### PR DESCRIPTION
## 概要

Admin/User側のタスクステータスバッジの幅を3文字基準で揃えました。

## 変更点

- タスクステータスバッジ用の共通コンポーネント `TaskStatusBadge` を追加しました。
- Adminタスク一覧のステータスバッジに `TaskStatusBadge` を適用しました。
- User/Mobileタスクカードのステータスバッジに `TaskStatusBadge` を適用しました。
- 幅は `min-w-16` とし、2文字の「完了」も3文字ステータスと同じ幅に見えつつ、将来長いステータスが追加されても横に広がれるようにしています。

## 関連Issue

- #69

## スクリーンショット（UI変更がある場合）

| User | Admin |
| ------ | ----- |
| <img width="452" height="424" alt="image" src="https://github.com/user-attachments/assets/93c79007-4010-49f1-9f01-0d4e8b3b99d8" />|  <img width="842" height="381" alt="image" src="https://github.com/user-attachments/assets/0d482c2b-71d7-4f25-9a30-ffc74fe990c2" />|

## 動作確認手順

1. Docker を起動した状態で `mise run dev` を実行する
2. `http://127.0.0.1:3000/login` にアクセスする
3. 管理者アカウントでログインする
4. `http://127.0.0.1:3000/admin/tasks` にアクセスし、ステータスバッジの幅を確認する
5. `http://127.0.0.1:3000/tasks` にアクセスし、User/Mobile側のステータスバッジの幅を確認する
6. `mise exec -- pnpm fmt:check .` を実行する
7. `mise exec -- pnpm lint` を実行する
8. `mise exec -- pnpm typecheck` を実行する
9. 終了時は `mise run down` を実行する

## レビューしてほしいポイント

- `TaskStatusBadge` として共通化する粒度で問題ないか
- `min-w-16` が3文字基準の幅として自然か
- Admin/User側で既存の色や見た目の意図を崩していないか

## セルフチェックリスト

- [ ] ローカルでの動作確認を行った
- [x] Lint エラーが出ていない
- [ ] テストコードを追加・修正した（必要な場合）
