### PR TITLE
[UI] フィルターやステータス変更のセレクトを通常時は下側に表示する

### DIFF
--- a/src/features/admin/tasks/ui/task-filter-bar.tsx
+++ b/src/features/admin/tasks/ui/task-filter-bar.tsx
@@ -70,7 +70,7 @@ function SelectFilter({
         )}
         <SelectValue placeholder={placeholder}>{value ? selectedLabel : placeholder}</SelectValue>
       </SelectTrigger>
-      <SelectContent className="max-w-[280px]">
+      <SelectContent position="popper" side="bottom" className="max-w-[280px]">
         <SelectItem value="all">すべて</SelectItem>
         {showGroups
           ? Array.from(optionGroups.entries()).map(([groupName, groupItems]) =>

--- a/src/features/admin/tasks/ui/task-form-dialog.tsx
+++ b/src/features/admin/tasks/ui/task-form-dialog.tsx
@@ -129,7 +129,7 @@ function TaskBasicSection({
             <SelectTrigger className="w-full">
               <SelectValue placeholder="選択してください" />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent position="popper" side="bottom">
               {EVENT_DAY_OPTIONS.map((option) => (
                 <SelectItem key={option.value} value={String(option.value)}>
                   {option.label}
@@ -153,7 +153,7 @@ function TaskBasicSection({
             <SelectTrigger className="w-full">
               <SelectValue placeholder="選択してください" />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent position="popper" side="bottom">
               {STATUS_OPTIONS.map((option) => (
                 <SelectItem key={option.value} value={String(option.value)}>
                   {option.label}
@@ -177,7 +177,7 @@ function TaskBasicSection({
             <SelectTrigger className="w-full">
               <SelectValue placeholder="選択してください" />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent position="popper" side="bottom">
               {filterOptions.leaders.map((leader) => (
                 <SelectItem key={leader.value} value={leader.value}>
                   {leader.label}
@@ -228,7 +228,7 @@ function TaskLocationSection({
             <SelectTrigger className="w-full">
               <SelectValue placeholder="選択してください" />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent position="popper" side="bottom">
               {Object.entries(locationGroups).map(([groupName, options]) =>
                 groupName ? (
                   <SelectGroup key={groupName}>
@@ -271,7 +271,7 @@ function TaskLocationSection({
             <SelectTrigger className="w-full">
               <SelectValue placeholder="選択してください" />
             </SelectTrigger>
-            <SelectContent>
+            <SelectContent position="popper" side="bottom">
               {Object.entries(locationGroups).map(([groupName, options]) =>
                 groupName ? (
                   <SelectGroup key={groupName}>
@@ -330,7 +330,7 @@ function TaskItemSection({
               <SelectTrigger className="w-full">
                 <SelectValue placeholder="物品名" />
               </SelectTrigger>
-              <SelectContent>
+              <SelectContent position="popper" side="bottom">
                 {filterOptions.items.map((item) => (
                   <SelectItem key={item.value} value={item.value}>
                     {item.label}
@@ -394,7 +394,7 @@ function TaskScheduleSection({
             <SelectTrigger className="w-full">
               <SelectValue placeholder="選択してください" />
             </SelectTrigger>
-            <SelectContent className="max-h-64">
+            <SelectContent position="popper" side="bottom" className="max-h-64">
               {filterOptions.timeOptions.map((time) => (
                 <SelectItem key={time} value={time}>
                   {time}
@@ -422,7 +422,7 @@ function TaskScheduleSection({
             <SelectTrigger className="w-full">
               <SelectValue placeholder="選択してください" />
             </SelectTrigger>
-            <SelectContent className="max-h-64">
+            <SelectContent position="popper" side="bottom" className="max-h-64">
               {filterOptions.timeOptions.map((time) => (
                 <SelectItem key={time} value={time}>
                   {time}

--- a/src/features/user/tasks/ui/task-detail-dialog.tsx
+++ b/src/features/user/tasks/ui/task-detail-dialog.tsx
@@ -161,7 +161,7 @@ export function TaskDetailDialog({
                 >
                   <SelectValue />
                 </SelectTrigger>
-                <SelectContent className="rounded-xl">
+                <SelectContent position="popper" side="bottom" className="rounded-xl">
                   {statusOptions().map((status) => (
                     <SelectItem key={status} value={String(status)}>
                       <span className="flex items-center gap-1.5">

--- a/src/features/user/tasks/ui/task-filter-sheet.tsx
+++ b/src/features/user/tasks/ui/task-filter-sheet.tsx
@@ -194,7 +194,11 @@ export function TaskFilterSheet({
                   >
                     <SelectValue placeholder="From（搬入元）" />
                   </SelectTrigger>
-                  <SelectContent className="rounded-lg p-1 shadow-[0px_4px_6px_rgba(0,0,0,0.1),0px_2px_4px_rgba(0,0,0,0.1)]">
+                  <SelectContent
+                    position="popper"
+                    side="bottom"
+                    className="rounded-lg p-1 shadow-[0px_4px_6px_rgba(0,0,0,0.1),0px_2px_4px_rgba(0,0,0,0.1)]"
+                  >
                     <SelectItem value="__none__">未選択</SelectItem>
                     <LocationSelectOptions options={locationGroups} />
                   </SelectContent>
@@ -227,7 +231,11 @@ export function TaskFilterSheet({
                   >
                     <SelectValue placeholder="To（搬入先）" />
                   </SelectTrigger>
-                  <SelectContent className="rounded-lg p-1 shadow-[0px_4px_6px_rgba(0,0,0,0.1),0px_2px_4px_rgba(0,0,0,0.1)]">
+                  <SelectContent
+                    position="popper"
+                    side="bottom"
+                    className="rounded-lg p-1 shadow-[0px_4px_6px_rgba(0,0,0,0.1),0px_2px_4px_rgba(0,0,0,0.1)]"
+                  >
                     <SelectItem value="__none__">未選択</SelectItem>
                     <LocationSelectOptions options={locationGroups} />
                   </SelectContent>


### PR DESCRIPTION
## 概要

Admin/User画面のフィルターとステータス変更で、セレクトメニューが通常時はトリガーの下側に表示されるようにしました。

画面下端など下側の表示領域が足りない場合は、既存の衝突回避によって表示位置を調整できる状態を維持しています。

## 変更点

- Adminタスク一覧のフィルター用セレクトを、通常時は下側に表示するよう変更しました。
- User/Mobileの絞り込みDrawerにあるFrom/Toセレクトを、通常時は下側に表示するよう変更しました。
- User/Mobileのタスク詳細Dialogにあるステータス変更セレクトを、通常時は下側に表示するよう変更しました。
- 共通の `SelectContent` や、対象外であるAdminタスク作成・編集Dialogのセレクトには変更を加えていません。
- 対象箇所だけに `position="popper"` と `side="bottom"` を指定し、Radix Selectの衝突回避挙動は維持しています。

## 関連Issue

- #70

## スクリーンショット（UI変更がある場合）
一部修正を載せます。

| 修正前 | 修正後 |
|----|----|
| <img width="1235" height="754" alt="image" src="https://github.com/user-attachments/assets/56da1513-0d6c-42e6-a7eb-4312d43b2c9a" />|<img width="2209" height="1441" alt="image" src="https://github.com/user-attachments/assets/d8632771-d301-4194-88f7-a26e3088f73e" />|
## 動作確認手順

1. Dockerを起動した状態で `mise run dev` を実行する
2. `http://127.0.0.1:3000/login` にアクセスし、管理者アカウントでログインする
3. `http://127.0.0.1:3000/admin/tasks` にアクセスし、各フィルターのセレクトが通常時は下側に表示されることを確認する
4. `http://127.0.0.1:3000/tasks` にアクセスし、「絞り込む」Drawer内のFrom/Toセレクトが通常時は下側に表示されることを確認する
5. User側のタスク詳細Dialogを開き、ステータス変更セレクトが通常時は下側に表示されることを確認する
6. 画面下端など表示領域が足りない場合に、メニューが見切れず表示位置が調整されることを確認する
7. `mise exec -- pnpm fmt:check src/features/admin/tasks/ui/task-filter-bar.tsx src/features/user/tasks/ui/task-filter-sheet.tsx src/features/user/tasks/ui/task-detail-dialog.tsx` を実行する
8. `mise exec -- pnpm lint src/features/admin/tasks/ui/task-filter-bar.tsx src/features/user/tasks/ui/task-filter-sheet.tsx src/features/user/tasks/ui/task-detail-dialog.tsx` を実行する
9. `mise exec -- pnpm typecheck` を実行する
10. 終了時は `mise run down` を実行する

## レビューしてほしいポイント

- Admin/User側の対象セレクトが通常時に下側へ表示されるか
- 画面下端での衝突回避を妨げていないか
- 共通コンポーネントを変更せず、対象箇所ごとに指定する粒度が適切か
- Adminタスク作成・編集Dialogなど、対象外のセレクトへ影響が出ていないか

## セルフチェックリスト

- [x] ローカルでの実画面確認を行った
- [x] Formatエラーが出ていない
- [x] Lintエラーが出ていない
- [x] TypeScriptエラーが出ていない
- [ ] テストコードを追加・修正した（必要な場合）